### PR TITLE
Connect Swift frontend to akaza-server for kana-kanji conversion

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -95,9 +95,23 @@ class AkazaInputController: IMKInputController {
         if let flushed = romajiConverter.flush() {
             text += flushed
         }
-        if !text.isEmpty {
-            client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+        guard !text.isEmpty else {
+            composedHiragana = ""
+            return
         }
+
+        // かな漢字変換を試行
+        if let result = akazaClient.convertSync(yomi: text) {
+            let converted = result.map { $0.first?.surface ?? "" }.joined()
+            if !converted.isEmpty {
+                client.insertText(converted, replacementRange: NSRange(location: NSNotFound, length: 0))
+                composedHiragana = ""
+                return
+            }
+        }
+
+        // フォールバック: 生ひらがなを確定
+        client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
         composedHiragana = ""
     }
 

--- a/Sources/AkazaIME/AkazaServerProcess.swift
+++ b/Sources/AkazaIME/AkazaServerProcess.swift
@@ -1,0 +1,80 @@
+import Cocoa
+
+class AkazaServerProcess {
+    private var process: Process?
+    private(set) var stdinPipe: Pipe?
+    private(set) var stdoutPipe: Pipe?
+
+    private var restartCount = 0
+    private var shouldRestart = true
+
+    var onRestart: (() -> Void)?
+
+    func start() {
+        let serverPath = Bundle.main.bundlePath + "/Contents/MacOS/akaza-server"
+        let modelPath = Bundle.main.bundlePath + "/Contents/Resources/model"
+
+        guard FileManager.default.fileExists(atPath: serverPath) else {
+            NSLog("AkazaIME: akaza-server not found at \(serverPath)")
+            return
+        }
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: serverPath)
+        proc.arguments = [modelPath]
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        proc.standardInput = stdin
+        proc.standardOutput = stdout
+        proc.standardError = FileHandle.nullDevice
+
+        proc.terminationHandler = { [weak self] terminatedProcess in
+            guard let self = self else { return }
+            let status = terminatedProcess.terminationStatus
+            NSLog("AkazaIME: akaza-server terminated with status \(status)")
+
+            guard self.shouldRestart else { return }
+
+            let delay = min(pow(2.0, Double(self.restartCount)), 60.0)
+            self.restartCount += 1
+            NSLog("AkazaIME: restarting akaza-server in \(delay)s (attempt \(self.restartCount))")
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + delay) { [weak self] in
+                guard let self = self, self.shouldRestart else { return }
+                self.start()
+                self.onRestart?()
+            }
+        }
+
+        do {
+            try proc.run()
+            NSLog("AkazaIME: akaza-server started (pid=\(proc.processIdentifier))")
+            self.process = proc
+            self.stdinPipe = stdin
+            self.stdoutPipe = stdout
+            self.restartCount = 0
+        } catch {
+            NSLog("AkazaIME: failed to start akaza-server: \(error)")
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.stop()
+        }
+    }
+
+    func stop() {
+        shouldRestart = false
+        guard let proc = process, proc.isRunning else { return }
+        NSLog("AkazaIME: stopping akaza-server")
+        proc.terminate()
+        proc.waitUntilExit()
+        process = nil
+        stdinPipe = nil
+        stdoutPipe = nil
+    }
+}

--- a/Sources/AkazaIME/JSONRPCClient.swift
+++ b/Sources/AkazaIME/JSONRPCClient.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+struct ConvertCandidate: Decodable {
+    let surface: String
+    let yomi: String
+    let cost: Float
+}
+
+typealias ConvertResult = [[ConvertCandidate]]
+
+class JSONRPCClient {
+    private let serverProcess: AkazaServerProcess
+    private var nextID = 1
+    private let requestQueue = DispatchQueue(label: "im.akaza.jsonrpc.request")
+    private var readerQueue: DispatchQueue?
+
+    private let lock = NSLock()
+    private var pendingRequests: [Int: (Data?) -> Void] = [:]
+
+    init(serverProcess: AkazaServerProcess) {
+        self.serverProcess = serverProcess
+        self.serverProcess.onRestart = { [weak self] in
+            self?.startReaderLoop()
+        }
+    }
+
+    func startReaderLoop() {
+        guard let stdout = serverProcess.stdoutPipe else { return }
+
+        let queue = DispatchQueue(label: "im.akaza.jsonrpc.reader")
+        self.readerQueue = queue
+
+        queue.async { [weak self] in
+            let handle = stdout.fileHandleForReading
+            var buffer = Data()
+
+            while true {
+                let chunk = handle.availableData
+                if chunk.isEmpty {
+                    // EOF - server terminated
+                    self?.failAllPending()
+                    break
+                }
+                buffer.append(chunk)
+
+                // Process complete lines
+                while let newlineRange = buffer.range(of: Data([0x0A])) {
+                    let lineData = buffer.subdata(in: buffer.startIndex..<newlineRange.lowerBound)
+                    buffer.removeSubrange(buffer.startIndex...newlineRange.lowerBound)
+
+                    guard !lineData.isEmpty else { continue }
+                    self?.handleResponse(lineData)
+                }
+            }
+        }
+    }
+
+    func convertSync(yomi: String) -> ConvertResult? {
+        let semaphore = DispatchSemaphore(value: 0)
+        var resultData: Data?
+
+        let requestID = requestQueue.sync { () -> Int in
+            let id = self.nextID
+            self.nextID += 1
+            return id
+        }
+
+        lock.lock()
+        pendingRequests[requestID] = { data in
+            resultData = data
+            semaphore.signal()
+        }
+        lock.unlock()
+
+        let request: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": requestID,
+            "method": "convert",
+            "params": ["yomi": yomi]
+        ]
+
+        requestQueue.async { [weak self] in
+            guard let self = self,
+                  let stdin = self.serverProcess.stdinPipe else {
+                self?.completePending(id: requestID, data: nil)
+                return
+            }
+
+            do {
+                var data = try JSONSerialization.data(withJSONObject: request)
+                data.append(0x0A) // newline
+                stdin.fileHandleForWriting.write(data)
+            } catch {
+                NSLog("AkazaIME: failed to serialize JSON-RPC request: \(error)")
+                self.completePending(id: requestID, data: nil)
+            }
+        }
+
+        let timeout = semaphore.wait(timeout: .now() + 1.0)
+        if timeout == .timedOut {
+            NSLog("AkazaIME: JSON-RPC request timed out (id=\(requestID))")
+            lock.lock()
+            pendingRequests.removeValue(forKey: requestID)
+            lock.unlock()
+            return nil
+        }
+
+        guard let data = resultData else { return nil }
+
+        do {
+            let result = try JSONDecoder().decode(ConvertResult.self, from: data)
+            return result
+        } catch {
+            NSLog("AkazaIME: failed to decode convert result: \(error)")
+            return nil
+        }
+    }
+
+    private func handleResponse(_ data: Data) {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = json["id"] as? Int else {
+            return
+        }
+
+        if let result = json["result"] {
+            if let resultData = try? JSONSerialization.data(withJSONObject: result) {
+                completePending(id: id, data: resultData)
+            } else {
+                completePending(id: id, data: nil)
+            }
+        } else {
+            if let error = json["error"] as? [String: Any] {
+                NSLog("AkazaIME: JSON-RPC error (id=\(id)): \(error)")
+            }
+            completePending(id: id, data: nil)
+        }
+    }
+
+    private func completePending(id: Int, data: Data?) {
+        lock.lock()
+        let callback = pendingRequests.removeValue(forKey: id)
+        lock.unlock()
+        callback?(data)
+    }
+
+    private func failAllPending() {
+        lock.lock()
+        let callbacks = pendingRequests
+        pendingRequests.removeAll()
+        lock.unlock()
+
+        for (_, callback) in callbacks {
+            callback(nil)
+        }
+    }
+}

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -37,5 +37,10 @@ guard let server = IMKServer(name: connectionName, bundleIdentifier: Bundle.main
 }
 _ = server // IMKServer を保持
 
+let akazaServerProcess = AkazaServerProcess()
+let akazaClient = JSONRPCClient(serverProcess: akazaServerProcess)
+akazaServerProcess.start()
+akazaClient.startReaderLoop()
+
 NSLog("AkazaIME: IMKServer created successfully")
 NSApplication.shared.run()


### PR DESCRIPTION
## Summary

- `AkazaServerProcess` を追加し、akaza-server プロセスのライフサイクル管理（起動・停止・クラッシュ時の指数バックオフ自動再起動）を実装
- `JSONRPCClient` を追加し、JSON-RPC 2.0 over stdin/stdout でのかな漢字変換リクエスト（同期呼び出し、1秒タイムアウト）を実装
- `commitText()` を変更し、Enter 確定時に akaza-server でかな漢字変換を行い、失敗時は生ひらがなにフォールバック

## Test plan

- [ ] `swift build` でコンパイルエラーがないことを確認
- [ ] `cargo build --release` で akaza-server がビルドできることを確認
- [ ] `make install` 後、IME を有効にしてひらがな入力 → Enter でかな漢字変換結果が確定されることを確認
- [ ] akaza-server 未配置の状態で Enter を押すと生ひらがながフォールバック確定されることを確認