### PR TITLE
Add candidate selection UI with clause navigation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 OUTDIR = out/
 APP = $(OUTDIR)/Akaza.app
 INSTALL_DIR = $(HOME)/Library/Input Methods
+MODEL_VERSION = v2026.0212.1
+MODEL_DIR = $(OUTDIR)/model
+MODEL_TARBALL = $(MODEL_DIR)/akaza-default-model.tar.gz
 
-.PHONY: all build install clean
+.PHONY: all build install clean download-model
 
 all: build
 
@@ -10,14 +13,29 @@ build:
 	swift build -c release
 	cargo build --release
 
-install: build
+download-model:
+	@if [ ! -f "$(MODEL_DIR)/akaza-default-model/unigram.model" ]; then \
+		echo "Downloading akaza-default-model $(MODEL_VERSION)..."; \
+		mkdir -p $(MODEL_DIR); \
+		gh release download $(MODEL_VERSION) \
+			--repo akaza-im/akaza-default-model \
+			--pattern "akaza-default-model.tar.gz" \
+			--dir $(MODEL_DIR) --clobber; \
+		tar xzf $(MODEL_TARBALL) -C $(MODEL_DIR); \
+	else \
+		echo "Model already downloaded."; \
+	fi
+
+install: build download-model
 	mkdir -p $(APP)/Contents/MacOS
-	mkdir -p $(APP)/Contents/Resources
+	mkdir -p $(APP)/Contents/Resources/model
 	rm -rf "$(INSTALL_DIR)/Akaza.app"
 	cp Info.plist $(APP)/Contents/
 	cp .build/release/AkazaIME $(APP)/Contents/MacOS/
 	cp target/release/akaza-server $(APP)/Contents/MacOS/
 	cp -r resources/* $(APP)/Contents/Resources/
+	cp $(MODEL_DIR)/akaza-default-model/*.model $(APP)/Contents/Resources/model/
+	cp $(MODEL_DIR)/akaza-default-model/SKK-JISYO.* $(APP)/Contents/Resources/model/
 	cp -a $(APP) "$(INSTALL_DIR)/"
 
 clean:

--- a/README.md
+++ b/README.md
@@ -224,6 +224,66 @@ killall AkazaIME
 - ビルドスクリプト整備
 - (将来) DMG / pkg インストーラー
 
+## トラブルシューティング
+
+### 変換結果が出ない / Space を押しても変換されない
+
+akaza-server がクラッシュしている可能性が高い。以下の手順で確認する。
+
+#### 1. ログを確認
+
+```bash
+tail -50 ~/Library/Logs/AkazaIME/akaza.log
+```
+
+`akaza-server terminated with status 1` が連続して出力されている場合、サーバーが起動直後にクラッシュしている。
+
+#### 2. akaza-server を手動で起動してエラーを確認
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"convert","params":{"yomi":"てすと"}}' | \
+  ~/Library/Input\ Methods/Akaza.app/Contents/MacOS/akaza-server \
+  ~/Library/Input\ Methods/Akaza.app/Contents/Resources/model 2>&1
+```
+
+stderr にエラーメッセージが出力される。
+
+#### 3. よくある原因: モデルデータが未配置
+
+```
+Error: No such file or directory (os error 2)
+```
+
+このエラーが出た場合、`Contents/Resources/model/` にモデルデータが配置されていない。`make install` はモデルのダウンロードも自動で行うので、再度実行する。
+
+```bash
+make install && killall AkazaIME
+```
+
+手動でモデルを配置する場合:
+
+```bash
+gh release download v2026.0212.1 \
+  --repo akaza-im/akaza-default-model \
+  --pattern "akaza-default-model.tar.gz" \
+  --dir /tmp
+tar xzf /tmp/akaza-default-model.tar.gz -C /tmp
+mkdir -p ~/Library/Input\ Methods/Akaza.app/Contents/Resources/model
+cp /tmp/akaza-default-model/*.model /tmp/akaza-default-model/SKK-JISYO.* \
+  ~/Library/Input\ Methods/Akaza.app/Contents/Resources/model/
+killall AkazaIME
+```
+
+### IME を切り替えても入力が反映されない
+
+```bash
+killall AkazaIME
+```
+
+次にテキスト入力欄にフォーカスすれば macOS が自動再起動する。
+
+初回インストール時や `Info.plist` の `InputMethodConnectionName` を変更した場合はログアウト・ログインが必要。
+
 ## Glossary
 
 - **preedit** - InputMethodKit では MarkedText と呼ばれる。変換確定前のテキスト

--- a/Sources/AkazaIME/AkazaInputController+Converting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Converting.swift
@@ -1,0 +1,165 @@
+import Cocoa
+import InputMethodKit
+
+// MARK: - Converting state handlers
+extension AkazaInputController {
+    func handleConvertingState(event: NSEvent, keyCode: UInt16, client: any IMKTextInput) -> Bool {
+        switch keyCode {
+        case 49, 125: // Space, Down arrow
+            return handleNextCandidateInConverting(client: client)
+        case 126: // Up arrow
+            return handlePreviousCandidateInConverting(client: client)
+        case 123: // Left arrow
+            return handlePreviousClauseInConverting(client: client)
+        case 124: // Right arrow
+            return handleNextClauseInConverting(client: client)
+        case 36: // Enter
+            return handleEnterInConverting(client: client)
+        case 53, 51: // Escape, Backspace
+            return handleEscapeInConverting(client: client)
+        default:
+            return handleDefaultKeyInConverting(event: event, client: client)
+        }
+    }
+
+    private func handleDefaultKeyInConverting(event: NSEvent, client: any IMKTextInput) -> Bool {
+        if let characters = event.characters, let char = characters.first,
+           let number = Int(String(char)), (1...9).contains(number) {
+            return handleNumberKeyInConverting(number: number, client: client)
+        }
+
+        if let characters = event.characters, !characters.isEmpty,
+           characters.first?.isLetter == true || characters.first == "-" {
+            commitConvertingText(client: client)
+            return handleCharacterInput(event: event, client: client)
+        }
+
+        return true
+    }
+
+    private func handleNextCandidateInConverting(client: any IMKTextInput) -> Bool {
+        guard case .converting(var session) = inputState else { return false }
+        session.nextCandidate()
+        inputState = .converting(session)
+        updateConvertingMarkedText(client: client)
+        showCandidateWindow(client: client)
+        return true
+    }
+
+    private func handlePreviousCandidateInConverting(client: any IMKTextInput) -> Bool {
+        guard case .converting(var session) = inputState else { return false }
+        session.previousCandidate()
+        inputState = .converting(session)
+        updateConvertingMarkedText(client: client)
+        showCandidateWindow(client: client)
+        return true
+    }
+
+    private func handlePreviousClauseInConverting(client: any IMKTextInput) -> Bool {
+        guard case .converting(var session) = inputState else { return false }
+        session.focusPreviousClause()
+        inputState = .converting(session)
+        updateConvertingMarkedText(client: client)
+        showCandidateWindow(client: client)
+        return true
+    }
+
+    private func handleNextClauseInConverting(client: any IMKTextInput) -> Bool {
+        guard case .converting(var session) = inputState else { return false }
+        session.focusNextClause()
+        inputState = .converting(session)
+        updateConvertingMarkedText(client: client)
+        showCandidateWindow(client: client)
+        return true
+    }
+
+    private func handleEnterInConverting(client: any IMKTextInput) -> Bool {
+        commitConvertingText(client: client)
+        return true
+    }
+
+    private func handleEscapeInConverting(client: any IMKTextInput) -> Bool {
+        guard case .converting(let session) = inputState else { return false }
+        composedHiragana = session.originalHiragana
+        inputState = .composing
+        Self.candidateWindow.hide()
+        updateComposingMarkedText(client: client)
+        return true
+    }
+
+    private func handleNumberKeyInConverting(number: Int, client: any IMKTextInput) -> Bool {
+        guard case .converting(var session) = inputState else { return false }
+        if session.selectCandidate(number: number) {
+            inputState = .converting(session)
+            commitConvertingText(client: client)
+        }
+        return true
+    }
+}
+
+// MARK: - Marked text display
+extension AkazaInputController {
+    func updateComposingMarkedText(client: any IMKTextInput) {
+        let preedit = composedHiragana + romajiConverter.pendingRomaji
+        if preedit.isEmpty {
+            client.setMarkedText(
+                "",
+                selectionRange: NSRange(location: 0, length: 0),
+                replacementRange: NSRange(location: NSNotFound, length: 0)
+            )
+        } else {
+            client.setMarkedText(
+                preedit,
+                selectionRange: NSRange(location: preedit.count, length: 0),
+                replacementRange: NSRange(location: NSNotFound, length: 0)
+            )
+        }
+    }
+
+    func updateConvertingMarkedText(client: any IMKTextInput) {
+        guard case .converting(let session) = inputState else { return }
+
+        let attributed = NSMutableAttributedString()
+
+        for (clauseIndex, candidates) in session.clauses.enumerated() {
+            guard !candidates.isEmpty else { continue }
+            let selectedIndex = session.selectedCandidateIndices[clauseIndex]
+            let surface = candidates[selectedIndex].surface
+            let isFocused = clauseIndex == session.focusedClauseIndex
+
+            let underlineStyle: NSUnderlineStyle = isFocused ? .thick : .single
+            let attrs: [NSAttributedString.Key: Any] = [
+                .underlineStyle: underlineStyle.rawValue,
+                .markedClauseSegment: clauseIndex
+            ]
+            let segment = NSAttributedString(string: surface, attributes: attrs)
+            attributed.append(segment)
+        }
+
+        let fullLength = attributed.length
+        client.setMarkedText(
+            attributed,
+            selectionRange: NSRange(location: fullLength, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+    }
+
+    func showCandidateWindow(client: any IMKTextInput) {
+        guard case .converting(let session) = inputState else { return }
+
+        let candidates = session.focusedCandidates
+        guard !candidates.isEmpty else {
+            Self.candidateWindow.hide()
+            return
+        }
+
+        var lineHeightRect = NSRect.zero
+        client.attributes(forCharacterIndex: 0, lineHeightRectangle: &lineHeightRect)
+
+        Self.candidateWindow.show(
+            candidates: candidates,
+            selectedIndex: session.focusedSelectedIndex,
+            cursorRect: lineHeightRect
+        )
+    }
+}

--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -3,12 +3,21 @@ import InputMethodKit
 
 @objc(AkazaInputController)
 class AkazaInputController: IMKInputController {
-    private var composedHiragana: String = ""
-    private let romajiConverter = RomajiConverter()
+    var composedHiragana: String = ""
+    let romajiConverter = RomajiConverter()
+    var inputState: InputState = .composing
+    static let candidateWindow = CandidateWindowController()
 
-    private var hasPreedit: Bool {
-        !composedHiragana.isEmpty || !romajiConverter.pendingRomaji.isEmpty
+    var hasPreedit: Bool {
+        switch inputState {
+        case .composing:
+            return !composedHiragana.isEmpty || !romajiConverter.pendingRomaji.isEmpty
+        case .converting:
+            return true
+        }
     }
+
+    // MARK: - Main event handler
 
     override func handle(_ event: NSEvent!, client sender: Any!) -> Bool {
         guard let event = event, event.type == .keyDown else {
@@ -23,46 +32,99 @@ class AkazaInputController: IMKInputController {
 
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         if flags.contains(.command) || flags.contains(.control) || flags.contains(.option) {
-            if hasPreedit { commitText(client: client) }
+            if hasPreedit { commitCurrentState(client: client) }
             return false
         }
 
-        switch keyCode {
-        case 36: return handleEnter(client: client)
-        case 53: return handleEscape(client: client)
-        case 51: return handleBackspace(client: client)
-        default: return handleCharacterInput(event: event, client: client)
+        switch inputState {
+        case .composing:
+            return handleComposingState(event: event, keyCode: keyCode, client: client)
+        case .converting:
+            return handleConvertingState(event: event, keyCode: keyCode, client: client)
         }
     }
 
-    private func handleEnter(client: any IMKTextInput) -> Bool {
-        guard hasPreedit else { return false }
-        commitText(client: client)
+    // MARK: - Composing state
+
+    private func handleComposingState(event: NSEvent, keyCode: UInt16, client: any IMKTextInput) -> Bool {
+        switch keyCode {
+        case 49: // Space
+            return handleSpaceInComposing(client: client)
+        case 36: // Enter
+            return handleEnterInComposing(client: client)
+        case 53: // Escape
+            return handleEscapeInComposing(client: client)
+        case 51: // Backspace
+            return handleBackspaceInComposing(client: client)
+        default:
+            return handleCharacterInput(event: event, client: client)
+        }
+    }
+
+    private func handleSpaceInComposing(client: any IMKTextInput) -> Bool {
+        guard hasPreedit else {
+            return false
+        }
+
+        var text = composedHiragana
+        if let flushed = romajiConverter.flush() {
+            text += flushed
+        }
+        guard !text.isEmpty else { return false }
+
+        guard let result = akazaClient.convertSync(yomi: text), !result.isEmpty else {
+            composedHiragana = text
+            updateComposingMarkedText(client: client)
+            return true
+        }
+
+        let session = ConversionSession(originalHiragana: text, clauses: result)
+        inputState = .converting(session)
+        composedHiragana = ""
+        updateConvertingMarkedText(client: client)
+        showCandidateWindow(client: client)
         return true
     }
 
-    private func handleEscape(client: any IMKTextInput) -> Bool {
+    private func handleEnterInComposing(client: any IMKTextInput) -> Bool {
+        guard hasPreedit else { return false }
+
+        var text = composedHiragana
+        if let flushed = romajiConverter.flush() {
+            text += flushed
+        }
+        guard !text.isEmpty else {
+            composedHiragana = ""
+            return true
+        }
+
+        client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+        composedHiragana = ""
+        return true
+    }
+
+    private func handleEscapeInComposing(client: any IMKTextInput) -> Bool {
         guard hasPreedit else { return false }
         composedHiragana = ""
         romajiConverter.clear()
-        updateMarkedText(client: client)
+        updateComposingMarkedText(client: client)
         return true
     }
 
-    private func handleBackspace(client: any IMKTextInput) -> Bool {
+    private func handleBackspaceInComposing(client: any IMKTextInput) -> Bool {
         if romajiConverter.backspace() {
-            updateMarkedText(client: client)
+            updateComposingMarkedText(client: client)
             return true
         }
         if !composedHiragana.isEmpty {
             composedHiragana.removeLast()
-            updateMarkedText(client: client)
+            updateComposingMarkedText(client: client)
             return true
         }
         return false
     }
 
-    private func handleCharacterInput(event: NSEvent, client: any IMKTextInput) -> Bool {
+    func handleCharacterInput(event: NSEvent, client: any IMKTextInput) -> Bool {
         guard let characters = event.characters, !characters.isEmpty else {
             return false
         }
@@ -76,7 +138,7 @@ class AkazaInputController: IMKInputController {
                     break
                 case .passthrough(let character):
                     if !composedHiragana.isEmpty {
-                        commitText(client: client)
+                        commitComposingText(client: client)
                     }
                     client.insertText(
                         String(character),
@@ -86,11 +148,22 @@ class AkazaInputController: IMKInputController {
                 }
             }
         }
-        updateMarkedText(client: client)
+        updateComposingMarkedText(client: client)
         return true
     }
 
-    private func commitText(client: any IMKTextInput) {
+    // MARK: - Commit helpers
+
+    func commitCurrentState(client: any IMKTextInput) {
+        switch inputState {
+        case .composing:
+            commitComposingText(client: client)
+        case .converting:
+            commitConvertingText(client: client)
+        }
+    }
+
+    func commitComposingText(client: any IMKTextInput) {
         var text = composedHiragana
         if let flushed = romajiConverter.flush() {
             text += flushed
@@ -99,36 +172,33 @@ class AkazaInputController: IMKInputController {
             composedHiragana = ""
             return
         }
-
-        // かな漢字変換を試行
-        if let result = akazaClient.convertSync(yomi: text) {
-            let converted = result.map { $0.first?.surface ?? "" }.joined()
-            if !converted.isEmpty {
-                client.insertText(converted, replacementRange: NSRange(location: NSNotFound, length: 0))
-                composedHiragana = ""
-                return
-            }
-        }
-
-        // フォールバック: 生ひらがなを確定
         client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
         composedHiragana = ""
     }
 
-    private func updateMarkedText(client: any IMKTextInput) {
-        let preedit = composedHiragana + romajiConverter.pendingRomaji
-        if preedit.isEmpty {
-            client.setMarkedText(
-                "",
-                selectionRange: NSRange(location: 0, length: 0),
-                replacementRange: NSRange(location: NSNotFound, length: 0)
-            )
-        } else {
-            client.setMarkedText(
-                preedit,
-                selectionRange: NSRange(location: preedit.count, length: 0),
-                replacementRange: NSRange(location: NSNotFound, length: 0)
-            )
+    func commitConvertingText(client: any IMKTextInput) {
+        guard case .converting(let session) = inputState else { return }
+        let text = session.committedText
+        client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+        resetToComposing()
+    }
+
+    func resetToComposing() {
+        inputState = .composing
+        composedHiragana = ""
+        romajiConverter.clear()
+        Self.candidateWindow.hide()
+    }
+
+    // MARK: - IMKInputController overrides
+
+    override func deactivateServer(_ sender: Any!) {
+        if let client = sender as? (any IMKTextInput) {
+            if hasPreedit {
+                commitCurrentState(client: client)
+            }
         }
+        resetToComposing()
+        super.deactivateServer(sender)
     }
 }

--- a/Sources/AkazaIME/CandidateWindowController.swift
+++ b/Sources/AkazaIME/CandidateWindowController.swift
@@ -1,0 +1,98 @@
+import Cocoa
+
+class CandidateWindowController {
+    private let panel: NSPanel
+    private let stackView: NSStackView
+    private let maxDisplayCount = 9
+    private var candidateLabels: [NSTextField] = []
+
+    init() {
+        panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: true
+        )
+        panel.level = .popUpMenu
+        panel.hidesOnDeactivate = false
+        panel.isOpaque = false
+        panel.backgroundColor = NSColor.windowBackgroundColor
+
+        stackView = NSStackView()
+        stackView.orientation = .vertical
+        stackView.alignment = .leading
+        stackView.spacing = 2
+        stackView.edgeInsets = NSEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        panel.contentView?.addSubview(stackView)
+        if let contentView = panel.contentView {
+            NSLayoutConstraint.activate([
+                stackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+                stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            ])
+        }
+    }
+
+    func show(candidates: [ConvertCandidate], selectedIndex: Int, cursorRect: NSRect) {
+        for label in candidateLabels {
+            stackView.removeArrangedSubview(label)
+            label.removeFromSuperview()
+        }
+        candidateLabels.removeAll()
+
+        let displayCount = min(candidates.count, maxDisplayCount)
+        guard displayCount > 0 else {
+            hide()
+            return
+        }
+
+        for idx in 0..<displayCount {
+            let candidate = candidates[idx]
+            let label = NSTextField(labelWithString: "\(idx + 1). \(candidate.surface)")
+            label.font = NSFont.systemFont(ofSize: 14)
+            label.translatesAutoresizingMaskIntoConstraints = false
+
+            if idx == selectedIndex {
+                label.backgroundColor = NSColor.selectedContentBackgroundColor
+                label.textColor = NSColor.white
+                label.drawsBackground = true
+            } else {
+                label.backgroundColor = .clear
+                label.textColor = NSColor.labelColor
+                label.drawsBackground = false
+            }
+
+            stackView.addArrangedSubview(label)
+            candidateLabels.append(label)
+        }
+
+        stackView.layoutSubtreeIfNeeded()
+        let contentSize = stackView.fittingSize
+        let panelWidth = max(contentSize.width + 16, 120)
+        let panelHeight = contentSize.height + 8
+
+        var origin = NSPoint(x: cursorRect.origin.x, y: cursorRect.origin.y - panelHeight)
+
+        // cursorRect が zero の場合のフォールバック
+        if cursorRect == .zero {
+            origin = NSPoint(x: 100, y: 100)
+        }
+
+        // 画面下端からはみ出す場合はカーソルの上に表示
+        if let screen = NSScreen.main {
+            if origin.y < screen.visibleFrame.origin.y {
+                origin.y = cursorRect.origin.y + cursorRect.size.height
+            }
+        }
+
+        panel.setFrame(NSRect(x: origin.x, y: origin.y, width: panelWidth, height: panelHeight), display: true)
+        panel.orderFront(nil)
+    }
+
+    func hide() {
+        panel.orderOut(nil)
+    }
+}

--- a/Sources/AkazaIME/ConversionSession.swift
+++ b/Sources/AkazaIME/ConversionSession.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+enum InputState {
+    case composing
+    case converting(ConversionSession)
+}
+
+struct ConversionSession {
+    let originalHiragana: String
+    let clauses: [[ConvertCandidate]]
+    var focusedClauseIndex: Int = 0
+    var selectedCandidateIndices: [Int]
+
+    init(originalHiragana: String, clauses: [[ConvertCandidate]]) {
+        self.originalHiragana = originalHiragana
+        self.clauses = clauses
+        self.selectedCandidateIndices = Array(repeating: 0, count: clauses.count)
+    }
+
+    var committedText: String {
+        clauses.enumerated().map { index, candidates in
+            guard !candidates.isEmpty else { return "" }
+            return candidates[selectedCandidateIndices[index]].surface
+        }.joined()
+    }
+
+    var focusedCandidates: [ConvertCandidate] {
+        guard focusedClauseIndex < clauses.count else { return [] }
+        return clauses[focusedClauseIndex]
+    }
+
+    var focusedSelectedIndex: Int {
+        guard focusedClauseIndex < selectedCandidateIndices.count else { return 0 }
+        return selectedCandidateIndices[focusedClauseIndex]
+    }
+
+    mutating func nextCandidate() {
+        guard !focusedCandidates.isEmpty else { return }
+        let count = focusedCandidates.count
+        selectedCandidateIndices[focusedClauseIndex] = (selectedCandidateIndices[focusedClauseIndex] + 1) % count
+    }
+
+    mutating func previousCandidate() {
+        guard !focusedCandidates.isEmpty else { return }
+        let count = focusedCandidates.count
+        let current = selectedCandidateIndices[focusedClauseIndex]
+        selectedCandidateIndices[focusedClauseIndex] = (current - 1 + count) % count
+    }
+
+    mutating func focusPreviousClause() {
+        if focusedClauseIndex > 0 {
+            focusedClauseIndex -= 1
+        }
+    }
+
+    mutating func focusNextClause() {
+        if focusedClauseIndex < clauses.count - 1 {
+            focusedClauseIndex += 1
+        }
+    }
+
+    mutating func selectCandidate(number: Int) -> Bool {
+        let index = number - 1
+        guard index >= 0, index < focusedCandidates.count else { return false }
+        selectedCandidateIndices[focusedClauseIndex] = index
+        return true
+    }
+}


### PR DESCRIPTION
## Summary
- Space キーで変換を開始し、文節ごとに候補を選択できる UI を実装
- NSPanel ベースの候補ウィンドウ (番号付き 1-9、ハイライト、カーソル位置配置)
- composing/converting の状態遷移を導入し、各状態でのキー操作を整理
- `make install` 時にモデルデータを自動ダウンロード・バンドルする `download-model` ターゲットを追加
- README.md にトラブルシューティングセクションを追加

## 新規ファイル
- `ConversionSession.swift` - 変換状態のデータモデル (文節フォーカス、候補選択)
- `CandidateWindowController.swift` - NSPanel ベースの候補ウィンドウ
- `AkazaInputController+Converting.swift` - converting state のハンドラと表示ロジック

## 状態遷移
- **composing state**: Space→変換開始、Enter→生ひらがな確定、Escape→クリア
- **converting state**: Space/↓→次候補、↑→前候補、←→→文節移動、Enter→確定、Escape/BS→ひらがな復元、1-9→直接選択

## Test plan
- [ ] `swift build` でコンパイルエラーなし
- [ ] `make install && killall AkazaIME` でインストール・再起動
- [ ] ローマ字入力 → Space で変換 → 候補ウィンドウ表示
- [ ] Space 再押下で次の候補に切替
- [ ] ←/→ で文節フォーカス移動
- [ ] Enter で変換確定
- [ ] Escape でひらがなに戻る
- [ ] 変換中に文字入力 → 確定 + 新しい入力開始
- [ ] モデル未配置時に `make install` でモデル自動ダウンロード