### PR TITLE
Fix character input handling and candidate window mouse events

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,4 @@
+excluded:
+  - .build
+
+line_length: 200

--- a/Sources/AkazaIME/AkazaInputController+Converting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Converting.swift
@@ -28,8 +28,8 @@ extension AkazaInputController {
             return handleNumberKeyInConverting(number: number, client: client)
         }
 
-        if let characters = event.characters, !characters.isEmpty,
-           characters.first?.isLetter == true || characters.first == "-" {
+        if let characters = event.characters, let first = characters.first,
+           !first.isNewline && !first.isWhitespace && (first.isLetter || first.isNumber || first.isPunctuation || first.isSymbol) {
             commitConvertingText(client: client)
             return handleCharacterInput(event: event, client: client)
         }

--- a/Sources/AkazaIME/CandidateWindowController.swift
+++ b/Sources/AkazaIME/CandidateWindowController.swift
@@ -17,6 +17,7 @@ class CandidateWindowController {
         panel.hidesOnDeactivate = false
         panel.isOpaque = false
         panel.backgroundColor = NSColor.windowBackgroundColor
+        panel.ignoresMouseEvents = true
 
         stackView = NSStackView()
         stackView.orientation = .vertical


### PR DESCRIPTION
Broaden character detection in converting mode to accept numbers, punctuation, and symbols in addition to letters. Set candidate window panel to ignore mouse events. Relax swiftlint line length limit.