### PR TITLE
Let akaza-server stderr inherit parent's log file

### DIFF
--- a/Sources/AkazaIME/AkazaServerProcess.swift
+++ b/Sources/AkazaIME/AkazaServerProcess.swift
@@ -27,7 +27,6 @@ class AkazaServerProcess {
         let stdout = Pipe()
         proc.standardInput = stdin
         proc.standardOutput = stdout
-        proc.standardError = FileHandle.nullDevice
 
         proc.terminationHandler = { [weak self] terminatedProcess in
             guard let self = self else { return }


### PR DESCRIPTION
## Summary
- `AkazaServerProcess` で `standardError = FileHandle.nullDevice` を削除し、子プロセスが親の stderr を継承するように変更
- 親プロセスの stderr は `~/Library/Logs/AkazaIME/akaza.log` にリダイレクト済みのため、libakaza の起動ログ（モデル・辞書・ユーザーデータのパス）がログファイルに出力されるようになる

## Test plan
- [ ] IME をビルド・インストールして起動
- [ ] `~/Library/Logs/AkazaIME/akaza.log` に libakaza のログ（モデルパス、辞書パス等）が出力されていることを確認