### PR TITLE
Add clause boundary resize with Shift+arrow keys

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Converting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Converting.swift
@@ -4,14 +4,22 @@ import InputMethodKit
 // MARK: - Converting state handlers
 extension AkazaInputController {
     func handleConvertingState(event: NSEvent, keyCode: UInt16, client: any IMKTextInput) -> Bool {
+        let isShiftPressed = event.modifierFlags.contains(.shift)
+
         switch keyCode {
         case 49, 125: // Space, Down arrow
             return handleNextCandidateInConverting(client: client)
         case 126: // Up arrow
             return handlePreviousCandidateInConverting(client: client)
         case 123: // Left arrow
+            if isShiftPressed {
+                return handleShrinkClauseLeft(client: client)
+            }
             return handlePreviousClauseInConverting(client: client)
         case 124: // Right arrow
+            if isShiftPressed {
+                return handleExtendClauseRight(client: client)
+            }
             return handleNextClauseInConverting(client: client)
         case 36: // Enter
             return handleEnterInConverting(client: client)
@@ -93,6 +101,38 @@ extension AkazaInputController {
             inputState = .converting(session)
             commitConvertingText(client: client)
         }
+        return true
+    }
+
+    private func handleExtendClauseRight(client: any IMKTextInput) -> Bool {
+        guard case .converting(let session) = inputState else { return false }
+        guard let (yomi, forceRanges) = session.forceRangesForExtendRight() else { return true }
+
+        let focusedIndex = session.focusedClauseIndex
+        guard let result = akazaClient.convertSync(yomi: yomi, forceRanges: forceRanges),
+              !result.isEmpty else { return true }
+
+        var newSession = ConversionSession(originalHiragana: yomi, clauses: result)
+        newSession.focusedClauseIndex = min(focusedIndex, newSession.clauses.count - 1)
+        inputState = .converting(newSession)
+        updateConvertingMarkedText(client: client)
+        showCandidateWindow(client: client)
+        return true
+    }
+
+    private func handleShrinkClauseLeft(client: any IMKTextInput) -> Bool {
+        guard case .converting(let session) = inputState else { return false }
+        guard let (yomi, forceRanges) = session.forceRangesForExtendLeft() else { return true }
+
+        let focusedIndex = session.focusedClauseIndex
+        guard let result = akazaClient.convertSync(yomi: yomi, forceRanges: forceRanges),
+              !result.isEmpty else { return true }
+
+        var newSession = ConversionSession(originalHiragana: yomi, clauses: result)
+        newSession.focusedClauseIndex = min(focusedIndex, newSession.clauses.count - 1)
+        inputState = .converting(newSession)
+        updateConvertingMarkedText(client: client)
+        showCandidateWindow(client: client)
         return true
     }
 }

--- a/Sources/AkazaIME/ConversionSession.swift
+++ b/Sources/AkazaIME/ConversionSession.swift
@@ -65,4 +65,68 @@ struct ConversionSession {
         selectedCandidateIndices[focusedClauseIndex] = index
         return true
     }
+
+    // MARK: - Clause boundary manipulation
+
+    var clauseYomis: [String] {
+        clauses.map { candidates in
+            candidates.first?.yomi ?? ""
+        }
+    }
+
+    /// 現在の文節を右に1文字伸ばした場合の yomi と force_ranges を返す
+    func forceRangesForExtendRight() -> (String, [[Int]])? {
+        let yomis = clauseYomis
+        // 最後の文節では次の文節がないので伸ばせない
+        guard focusedClauseIndex < yomis.count - 1 else { return nil }
+
+        let nextYomi = yomis[focusedClauseIndex + 1]
+        guard !nextYomi.isEmpty else { return nil }
+
+        // 次の文節の先頭1文字を現在の文節に移す
+        let firstChar = String(nextYomi.prefix(1))
+        let remaining = String(nextYomi.dropFirst())
+
+        var newYomis = yomis
+        newYomis[focusedClauseIndex] += firstChar
+        if remaining.isEmpty {
+            newYomis.remove(at: focusedClauseIndex + 1)
+        } else {
+            newYomis[focusedClauseIndex + 1] = remaining
+        }
+
+        return (originalHiragana, buildForceRanges(newYomis))
+    }
+
+    /// 現在の文節を左に1文字縮めた場合の yomi と force_ranges を返す
+    func forceRangesForExtendLeft() -> (String, [[Int]])? {
+        let yomis = clauseYomis
+        let currentYomi = yomis[focusedClauseIndex]
+
+        // 1文字しかない文節は縮められない
+        guard currentYomi.count > 1 else { return nil }
+        // 最後の文節では次の文節に文字を渡せない
+        guard focusedClauseIndex < yomis.count - 1 else { return nil }
+
+        // 現在の文節の末尾1文字を次の文節の先頭に移す
+        let lastChar = String(currentYomi.suffix(1))
+        let shortened = String(currentYomi.dropLast())
+
+        var newYomis = yomis
+        newYomis[focusedClauseIndex] = shortened
+        newYomis[focusedClauseIndex + 1] = lastChar + newYomis[focusedClauseIndex + 1]
+
+        return (originalHiragana, buildForceRanges(newYomis))
+    }
+
+    private func buildForceRanges(_ yomis: [String]) -> [[Int]] {
+        var ranges: [[Int]] = []
+        var byteOffset = 0
+        for yomi in yomis {
+            let byteCount = yomi.utf8.count
+            ranges.append([byteOffset, byteOffset + byteCount])
+            byteOffset += byteCount
+        }
+        return ranges
+    }
 }

--- a/Sources/AkazaIME/JSONRPCClient.swift
+++ b/Sources/AkazaIME/JSONRPCClient.swift
@@ -55,7 +55,23 @@ class JSONRPCClient {
         }
     }
 
-    func convertSync(yomi: String) -> ConvertResult? {
+    func convertSync(yomi: String, forceRanges: [[Int]]? = nil) -> ConvertResult? {
+        var params: [String: Any] = ["yomi": yomi]
+        if let forceRanges = forceRanges {
+            params["force_ranges"] = forceRanges
+        }
+
+        guard let data = sendRequestSync(method: "convert", params: params) else { return nil }
+
+        do {
+            return try JSONDecoder().decode(ConvertResult.self, from: data)
+        } catch {
+            NSLog("AkazaIME: failed to decode convert result: \(error)")
+            return nil
+        }
+    }
+
+    private func sendRequestSync(method: String, params: [String: Any]) -> Data? {
         let semaphore = DispatchSemaphore(value: 0)
         var resultData: Data?
 
@@ -75,8 +91,8 @@ class JSONRPCClient {
         let request: [String: Any] = [
             "jsonrpc": "2.0",
             "id": requestID,
-            "method": "convert",
-            "params": ["yomi": yomi]
+            "method": method,
+            "params": params
         ]
 
         requestQueue.async { [weak self] in
@@ -105,15 +121,7 @@ class JSONRPCClient {
             return nil
         }
 
-        guard let data = resultData else { return nil }
-
-        do {
-            let result = try JSONDecoder().decode(ConvertResult.self, from: data)
-            return result
-        } catch {
-            NSLog("AkazaIME: failed to decode convert result: \(error)")
-            return nil
-        }
+        return resultData
     }
 
     private func handleResponse(_ data: Data) {

--- a/akaza-server/src/handler.rs
+++ b/akaza-server/src/handler.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use libakaza::engine::base::HenkanEngine;
 use libakaza::engine::bigram_word_viterbi_engine::BigramWordViterbiEngine;
 use libakaza::graph::candidate::Candidate;
@@ -55,7 +57,11 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
             }
         };
 
-        match self.engine.convert(&params.yomi, None) {
+        let force_ranges: Option<Vec<Range<usize>>> = params
+            .force_ranges
+            .map(|ranges| ranges.into_iter().map(|r| r[0]..r[1]).collect());
+
+        match self.engine.convert(&params.yomi, force_ranges.as_deref()) {
             Ok(clauses) => {
                 let result = Self::clauses_to_json(&clauses);
                 Response::success(request.id.clone(), result)

--- a/akaza-server/src/jsonrpc.rs
+++ b/akaza-server/src/jsonrpc.rs
@@ -20,6 +20,8 @@ pub struct Request {
 #[derive(Debug, Deserialize)]
 pub struct ConvertParams {
     pub yomi: String,
+    #[serde(default)]
+    pub force_ranges: Option<Vec<Vec<usize>>>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary
- Shift+右矢印で変換中の文節を右に伸ばす（次の文節から1文字取る）
- Shift+左矢印で変換中の文節を左に縮める（末尾1文字を次の文節に渡す）
- akaza-server の `convert` API に `force_ranges` パラメータを追加し、文節境界を指定した再変換を可能に

## Changes
- **akaza-server**: `ConvertParams` に `force_ranges` フィールド追加、`handle_convert` で `Vec<Range<usize>>` に変換して `engine.convert()` に渡す
- **JSONRPCClient**: `convertSync` に `forceRanges` パラメータ追加、リクエスト送信ロジックを `sendRequestSync` に抽出
- **ConversionSession**: `clauseYomis`, `forceRangesForExtendRight()`, `forceRangesForExtendLeft()` を追加
- **AkazaInputController+Converting**: Shift キー判定を追加し、文節伸縮ハンドラを実装

## Test plan
- [ ] 「わたしはがくせいです」等を変換し、Shift+右で文節が伸びることを確認
- [ ] Shift+左で文節が縮むことを確認
- [ ] 最初の文節・最後の文節で端の操作をしても壊れないことを確認
- [ ] 通常の左右矢印による文節フォーカス移動が引き続き動作することを確認
- [ ] force_ranges なしの通常変換が引き続き動作することを確認