### PR TITLE
Add paging support to candidate window

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Converting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Converting.swift
@@ -97,7 +97,10 @@ extension AkazaInputController {
 
     private func handleNumberKeyInConverting(number: Int, client: any IMKTextInput) -> Bool {
         guard case .converting(var session) = inputState else { return false }
-        if session.selectCandidate(number: number) {
+        let pageSize = 9
+        let currentPage = session.focusedSelectedIndex / pageSize
+        let absoluteIndex = currentPage * pageSize + number  // number は 1-based、selectCandidate も 1-based
+        if session.selectCandidate(number: absoluteIndex) {
             inputState = .converting(session)
             commitConvertingText(client: client)
         }

--- a/Sources/AkazaIME/CandidateWindowController.swift
+++ b/Sources/AkazaIME/CandidateWindowController.swift
@@ -38,21 +38,43 @@ class CandidateWindowController {
     }
 
     func show(candidates: [ConvertCandidate], selectedIndex: Int, cursorRect: NSRect) {
+        clearLabels()
+
+        guard !candidates.isEmpty else {
+            hide()
+            return
+        }
+
+        let pageSize = maxDisplayCount
+        let currentPage = selectedIndex / pageSize
+        let pageStart = currentPage * pageSize
+        let pageEnd = min(pageStart + pageSize, candidates.count)
+        let totalPages = (candidates.count + pageSize - 1) / pageSize
+
+        addCandidateLabels(candidates: candidates, pageStart: pageStart, pageEnd: pageEnd, selectedIndex: selectedIndex)
+
+        if totalPages > 1 {
+            addPageIndicator(currentPage: currentPage, totalPages: totalPages)
+        }
+
+        positionPanel(cursorRect: cursorRect)
+    }
+
+    private func clearLabels() {
         for label in candidateLabels {
             stackView.removeArrangedSubview(label)
             label.removeFromSuperview()
         }
         candidateLabels.removeAll()
+    }
 
-        let displayCount = min(candidates.count, maxDisplayCount)
-        guard displayCount > 0 else {
-            hide()
-            return
-        }
-
-        for idx in 0..<displayCount {
+    private func addCandidateLabels(
+        candidates: [ConvertCandidate], pageStart: Int, pageEnd: Int, selectedIndex: Int
+    ) {
+        for idx in pageStart..<pageEnd {
             let candidate = candidates[idx]
-            let label = NSTextField(labelWithString: "\(idx + 1). \(candidate.surface)")
+            let displayNumber = idx - pageStart + 1
+            let label = NSTextField(labelWithString: "\(displayNumber). \(candidate.surface)")
             label.font = NSFont.systemFont(ofSize: 14)
             label.translatesAutoresizingMaskIntoConstraints = false
 
@@ -69,7 +91,19 @@ class CandidateWindowController {
             stackView.addArrangedSubview(label)
             candidateLabels.append(label)
         }
+    }
 
+    private func addPageIndicator(currentPage: Int, totalPages: Int) {
+        let pageIndicator = NSTextField(labelWithString: "[\(currentPage + 1)/\(totalPages)]")
+        pageIndicator.font = NSFont.systemFont(ofSize: 12)
+        pageIndicator.textColor = NSColor.secondaryLabelColor
+        pageIndicator.alignment = .center
+        pageIndicator.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(pageIndicator)
+        candidateLabels.append(pageIndicator)
+    }
+
+    private func positionPanel(cursorRect: NSRect) {
         stackView.layoutSubtreeIfNeeded()
         let contentSize = stackView.fittingSize
         let panelWidth = max(contentSize.width + 16, 120)


### PR DESCRIPTION
## Summary
- 候補が9個を超える場合、候補ウィンドウをページング表示するように対応
- `selectedIndex` に基づいて現在のページを自動計算し、該当ページの候補のみ表示
- 2ページ以上ある場合、ウィンドウ下部にページインジケータ `[1/N]` を表示
- 数字キーが現在表示中のページの候補を正しく選択するように修正

## Test plan
- [ ] 候補が9個以下の場合、従来通り動作すること
- [ ] 候補が10個以上の場合、↓キーで次ページに遷移しラベルが 1〜N に更新されること
- [ ] 次ページで数字キー押下時、そのページの候補が正しく選択されること
- [ ] ↑キーでページ先頭から前ページ末尾に戻れること
- [ ] ページインジケータ `[1/N]` が正しく表示されること