### PR TITLE
Fix number keys not entering preedit in composing state

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -137,14 +137,18 @@ class AkazaInputController: IMKInputController {
                 case .pending:
                     break
                 case .passthrough(let character):
-                    if !composedHiragana.isEmpty {
-                        commitComposingText(client: client)
+                    if character.isNumber {
+                        composedHiragana += String(character)
+                    } else {
+                        if !composedHiragana.isEmpty {
+                            commitComposingText(client: client)
+                        }
+                        client.insertText(
+                            String(character),
+                            replacementRange: NSRange(location: NSNotFound, length: 0)
+                        )
+                        return true
                     }
-                    client.insertText(
-                        String(character),
-                        replacementRange: NSRange(location: NSNotFound, length: 0)
-                    )
-                    return true
                 }
             }
         }


### PR DESCRIPTION
## Summary
- composing 状態で数字キー（0-9）を押した際、直接確定されてしまう問題を修正
- 数字が `RomajiConverter` で `.passthrough` として返されるため `insertText` で直接挿入されていた
- 数字は `composedHiragana` に追加して preedit（変換前テキスト）の一部として扱うように変更

## Test plan
- [ ] composing 状態で `100` と入力すると preedit に `100` が表示されること
- [ ] `100えん` のように数字とひらがなの混合入力ができること
- [ ] preedit がない状態で数字を入力しても preedit に入ること
- [ ] converting 状態での数字キーによる候補選択は従来通り動作すること