### PR TITLE
Allow symbols to enter preedit

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -137,18 +137,7 @@ class AkazaInputController: IMKInputController {
                 case .pending:
                     break
                 case .passthrough(let character):
-                    if character.isNumber {
-                        composedHiragana += String(character)
-                    } else {
-                        if !composedHiragana.isEmpty {
-                            commitComposingText(client: client)
-                        }
-                        client.insertText(
-                            String(character),
-                            replacementRange: NSRange(location: NSNotFound, length: 0)
-                        )
-                        return true
-                    }
+                    composedHiragana += String(character)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `?`, `!`, `/` などローマ字マッピングにない記号が preedit に入らず直接挿入されていた問題を修正
- passthrough 文字を数字のみに限定していた条件を削除し、すべての passthrough 文字を preedit に追加するように変更

## Test plan
- [ ] `?` を入力 → preedit に `?` が表示される
- [ ] `なに？` と入力 → preedit に `なに？` が表示される
- [ ] `.` `,` `[` `]` `-` はローマ字マッピング経由で従来通り `。` `、` `「` `」` `ー` に変換される