### PR TITLE
Fix control characters appearing in preedit

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -130,9 +130,10 @@ class AkazaInputController: IMKInputController {
         }
         for char in characters {
             // Skip control characters (e.g. Ctrl+P = 0x10, DEL = 0x7F)
+            // Return true to consume the event and prevent direct input
             let scalar = char.unicodeScalars.first!.value
             if scalar < 0x20 || scalar == 0x7F {
-                return false
+                return true
             }
             let results = romajiConverter.feed(char)
             for result in results {


### PR DESCRIPTION
## Summary

- Ctrl+P などのコントロールキー操作時に、preedit に `^P` のような制御文字が表示されるバグを修正
- `handleCharacterInput` で C0 制御文字 (< 0x20) と DEL (0x7F) をフィルタリング

## Root cause

InputMethodKit が `handle(_:client:)` に渡す `NSEvent` の `modifierFlags` に `.control` が正しく設定されないケースがあり、既存の修飾キーチェック (Line 33-36) をすり抜ける。`event.characters` が制御文字（例: Ctrl+P → `\u{10}`）を返し、`RomajiConverter.feed()` の `.passthrough` パスを経由して `composedHiragana` に追加されていた。

## Test plan

- [ ] Ctrl+P, Ctrl+N 等を入力して preedit に制御文字が表示されないことを確認
- [ ] 通常のローマ字入力が従来通り動作すること