### PR TITLE
Support Ctrl+H as backspace in composing state

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -129,9 +129,12 @@ class AkazaInputController: IMKInputController {
             return false
         }
         for char in characters {
-            // Skip control characters (e.g. Ctrl+P = 0x10, DEL = 0x7F)
-            // Return true to consume the event and prevent direct input
             let scalar = char.unicodeScalars.first!.value
+            // Ctrl+H (BS = 0x08): treat as backspace
+            if scalar == 0x08 {
+                return handleBackspaceInComposing(client: client)
+            }
+            // Skip other control characters (e.g. Ctrl+P = 0x10, DEL = 0x7F)
             if scalar < 0x20 || scalar == 0x7F {
                 return true
             }


### PR DESCRIPTION
## Summary

- preedit 入力中に Ctrl+H でバックスペースが効くように修正
- Ctrl+H が生成する BS (0x08) を制御文字フィルタから分離し、`handleBackspaceInComposing` にルーティング

## Test plan

- [ ] preedit 入力中に Ctrl+H で直前の文字が削除されることを確認
- [ ] 通常の Backspace キーが従来通り動作すること
- [ ] 他の制御文字（Ctrl+P 等）が入力されないことを確認