### PR TITLE
Fix arrow keys causing tofu characters in composing state

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -56,6 +56,10 @@ class AkazaInputController: IMKInputController {
             return handleEscapeInComposing(client: client)
         case 51: // Backspace
             return handleBackspaceInComposing(client: client)
+        case 123, 124, 125, 126: // Arrow keys (Left, Right, Down, Up)
+            // If we have preedit, consume the arrow key without doing anything
+            // If no preedit, let the system handle it (return false)
+            return hasPreedit
         default:
             return handleCharacterInput(event: event, client: client)
         }


### PR DESCRIPTION
## Summary
- composing state で矢印キー（上下左右）を明示的に処理するようにした
- preedit がある場合：矢印キーを消費して何もしない
- preedit がない場合：システムに処理を委ねてカーソル移動として機能

これにより、入力中に矢印キーを押したときに豆腐（表示できない文字）が入力される問題を修正

## Test plan
- [ ] 入力中（preeditがある状態）に矢印キーを押して、豆腐が入力されないことを確認
- [ ] 入力していない状態で矢印キーを押して、通常のカーソル移動が動作することを確認
- [ ] converting state での矢印キーの動作（候補選択、文節移動）が引き続き動作することを確認