### PR TITLE
Persist learned user data to disk

### DIFF
--- a/akaza-server/src/handler.rs
+++ b/akaza-server/src/handler.rs
@@ -140,6 +140,28 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
         self.engine.learn(&candidates);
         info!("Learned {} candidates", candidates.len());
 
+        // Persist learned data to disk
+        match self.engine.user_data.lock() {
+            Ok(mut user_data) => {
+                if let Err(e) = user_data.write_user_files() {
+                    error!("learn: failed to save user data: {}", e);
+                    return Response::error(
+                        request.id.clone(),
+                        INTERNAL_ERROR,
+                        format!("Failed to save learned data: {}", e),
+                    );
+                }
+            }
+            Err(e) => {
+                error!("learn: failed to lock user_data: {}", e);
+                return Response::error(
+                    request.id.clone(),
+                    INTERNAL_ERROR,
+                    "Failed to access user data".to_string(),
+                );
+            }
+        }
+
         Response::success(request.id.clone(), Value::Bool(true))
     }
 


### PR DESCRIPTION
## Summary
- 学習データ(unigram/bigram/skip-bigram)がディスクに保存されていなかった問題を修正
- `learn` JSON-RPC メソッド実行後に `write_user_files()` を呼び出し、学習データを永続化
- これにより akaza-server プロセス再起動後も学習データが保持されるようになる

## 背景
これまで、変換確定時に `learn` メソッドが呼ばれ、メモリ上では学習データが記録されていましたが、ディスクへの保存処理が抜けていました。そのため、IME を再起動すると学習データが失われていました。

一方、ユーザー辞書 (`user_dict_add`/`user_dict_delete`) は正しくディスクに保存されていました。

## 変更内容
`akaza-server/src/handler.rs` の `handle_learn` メソッドで、`self.engine.learn()` 実行後に `user_data.write_user_files()` を呼び出すように修正。

## Test plan
- [ ] IME をビルドしてインストール
- [ ] 何度か変換・確定を行う
- [ ] IME を再起動 (`killall AkazaIME` など)
- [ ] 再起動後も学習結果が反映されていることを確認
- [ ] `~/.local/share/akaza/unigram.v1.txt` などのファイルが更新されていることを確認