### PR TITLE
Fix backspace behavior with input history

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -1,12 +1,18 @@
 import Cocoa
 import InputMethodKit
 
+struct ComposingSnapshot {
+    let composedHiragana: String
+    let romajiBuffer: String
+}
+
 @objc(AkazaInputController)
 class AkazaInputController: IMKInputController {
     var composedHiragana: String = ""
     let romajiConverter = RomajiConverter()
     var inputState: InputState = .composing
     static let candidateWindow = CandidateWindowController()
+    var inputHistory: [ComposingSnapshot] = []
 
     var hasPreedit: Bool {
         switch inputState {
@@ -78,6 +84,7 @@ class AkazaInputController: IMKInputController {
 
         guard let result = akazaClient.convertSync(yomi: text), !result.isEmpty else {
             composedHiragana = text
+            clearInputHistory()
             updateComposingMarkedText(client: client)
             return true
         }
@@ -85,6 +92,7 @@ class AkazaInputController: IMKInputController {
         let session = ConversionSession(originalHiragana: text, clauses: result)
         inputState = .converting(session)
         composedHiragana = ""
+        clearInputHistory()
         updateConvertingMarkedText(client: client)
         showCandidateWindow(client: client)
         return true
@@ -99,11 +107,13 @@ class AkazaInputController: IMKInputController {
         }
         guard !text.isEmpty else {
             composedHiragana = ""
+            clearInputHistory()
             return true
         }
 
         client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
         composedHiragana = ""
+        clearInputHistory()
         return true
     }
 
@@ -111,21 +121,20 @@ class AkazaInputController: IMKInputController {
         guard hasPreedit else { return false }
         composedHiragana = ""
         romajiConverter.clear()
+        clearInputHistory()
         updateComposingMarkedText(client: client)
         return true
     }
 
     private func handleBackspaceInComposing(client: any IMKTextInput) -> Bool {
-        if romajiConverter.backspace() {
-            updateComposingMarkedText(client: client)
-            return true
-        }
-        if !composedHiragana.isEmpty {
-            composedHiragana.removeLast()
-            updateComposingMarkedText(client: client)
-            return true
-        }
-        return false
+        // Restore from input history if available
+        guard !inputHistory.isEmpty else { return false }
+
+        let snapshot = inputHistory.removeLast()
+        composedHiragana = snapshot.composedHiragana
+        romajiConverter.setBuffer(snapshot.romajiBuffer)
+        updateComposingMarkedText(client: client)
+        return true
     }
 
     func handleCharacterInput(event: NSEvent, client: any IMKTextInput) -> Bool {
@@ -142,6 +151,10 @@ class AkazaInputController: IMKInputController {
             if scalar < 0x20 || scalar == 0x7F {
                 return true
             }
+
+            // Save current state before processing input
+            saveInputSnapshot()
+
             let results = romajiConverter.feed(char)
             for result in results {
                 switch result {
@@ -156,6 +169,20 @@ class AkazaInputController: IMKInputController {
         }
         updateComposingMarkedText(client: client)
         return true
+    }
+
+    // MARK: - Input history
+
+    private func saveInputSnapshot() {
+        let snapshot = ComposingSnapshot(
+            composedHiragana: composedHiragana,
+            romajiBuffer: romajiConverter.pendingRomaji
+        )
+        inputHistory.append(snapshot)
+    }
+
+    private func clearInputHistory() {
+        inputHistory.removeAll()
     }
 
     // MARK: - Commit helpers
@@ -176,10 +203,12 @@ class AkazaInputController: IMKInputController {
         }
         guard !text.isEmpty else {
             composedHiragana = ""
+            clearInputHistory()
             return
         }
         client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
         composedHiragana = ""
+        clearInputHistory()
     }
 
     func commitConvertingText(client: any IMKTextInput) {
@@ -194,6 +223,7 @@ class AkazaInputController: IMKInputController {
         inputState = .composing
         composedHiragana = ""
         romajiConverter.clear()
+        clearInputHistory()
         Self.candidateWindow.hide()
     }
 

--- a/Sources/AkazaIME/RomajiConverter.swift
+++ b/Sources/AkazaIME/RomajiConverter.swift
@@ -144,4 +144,8 @@ class RomajiConverter {
     func clear() {
         buffer = ""
     }
+
+    func setBuffer(_ newBuffer: String) {
+        buffer = newBuffer
+    }
 }


### PR DESCRIPTION
## Summary
- バックスペースの挙動を入力履歴ベースに修正
- 各文字入力前の状態(composedHiragana + romajiBuffer)をスナップショットとして保存
- バックスペース時に1つ前のスナップショットに復元

## 問題
以前は `s a t k <BACKSPACE> o` と入力すると "さtお" になっていました。期待される動作は "さと" です。

### 原因
1. "sa" → "さ" (変換)
2. "t" → pending (buffer = "t")
3. "k" → "tk" はマッチしないので "t" を passthrough、buffer = "k"
   - 結果: composedHiragana = "さt", buffer = "k"
4. <BACKSPACE> → buffer から "k" のみ削除
   - composedHiragana = "さt" (そのまま)
5. "o" → "お" に変換
   - 結果: "さtお"

従来のバックスペース処理は pending romaji buffer または composedHiragana の最後の文字を削除するだけで、ローマ字変換の途中状態を復元できませんでした。

## 変更内容
### 入力履歴の追加
- `ComposingSnapshot` 構造体を追加し、各文字入力前の状態を記録
- `inputHistory` スタックで履歴を管理

### バックスペース処理の変更
- 履歴スタックから1つ前の状態を復元
- composedHiragana と romajiBuffer の両方を復元

### 履歴のクリア
- Escape, Enter, Space(変換)時に履歴をクリア
- 変換モードへの移行時、確定時にも履歴をクリア

## Test plan
- [ ] IME をビルドしてインストール
- [ ] `s a t k <BACKSPACE> o` と入力して "さと" になることを確認
- [ ] `k a n n <BACKSPACE> j i` と入力して "かんじ" になることを確認
- [ ] 通常のバックスペース操作が正しく動作することを確認
- [ ] Enter/Escape/Space で確定後、バックスペースが効かないことを確認