### PR TITLE
Update akaza-default-model to v2026.218.0 from akaza-im/akaza

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ OUTDIR = out/
 APP = $(OUTDIR)/Akaza.app
 INSTALL_DIR = $(HOME)/Library/Input Methods
 MODEL_VERSION = v2026.218.0
-MODEL_DIR = $(OUTDIR)/model
+MODEL_DIR = $(OUTDIR)/model/$(MODEL_VERSION)
 MODEL_TARBALL = $(MODEL_DIR)/akaza-default-model.tar.gz
 
 .PHONY: all build install clean download-model


### PR DESCRIPTION
## Summary

- `MODEL_VERSION` を `v2026.0212.1` → `v2026.218.0` に更新
- モデルのダウンロード元を `akaza-im/akaza-default-model` → `akaza-im/akaza` に変更（モノレポ統合に対応）