### PR TITLE
Fix preedit caret position

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Converting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Converting.swift
@@ -146,14 +146,19 @@ extension AkazaInputController {
         let preedit = composedHiragana + romajiConverter.pendingRomaji
         if preedit.isEmpty {
             client.setMarkedText(
-                "",
+                NSAttributedString(string: ""),
                 selectionRange: NSRange(location: 0, length: 0),
                 replacementRange: NSRange(location: NSNotFound, length: 0)
             )
         } else {
+            let attrs: [NSAttributedString.Key: Any] = [
+                .underlineStyle: NSUnderlineStyle.single.rawValue
+            ]
+            let attributed = NSAttributedString(string: preedit, attributes: attrs)
+            let length = (preedit as NSString).length
             client.setMarkedText(
-                preedit,
-                selectionRange: NSRange(location: preedit.count, length: 0),
+                attributed,
+                selectionRange: NSRange(location: length, length: 0),
                 replacementRange: NSRange(location: NSNotFound, length: 0)
             )
         }


### PR DESCRIPTION
## Summary

- `setMarkedText` に plain String ではなく `NSAttributedString`（underline スタイル付き）を渡すよう変更
- アプリによっては plain String の `selectionRange` を無視し、キャレットが先頭に表示されるままになる問題を修正
- `preedit.count`（Swift の grapheme cluster 数）を `(preedit as NSString).length`（UTF-16 長）に変更し、NSRange との整合性を確保

## Test plan

- [ ] 各種アプリ（Terminal、テキストエディタ等）でひらがな入力時にキャレットが preedit 末尾に表示されることを確認