### PR TITLE
Fix duplicate entries in k-best suggestion candidates

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Suggesting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Suggesting.swift
@@ -103,23 +103,29 @@ extension AkazaInputController {
     func showSuggestCandidateWindow(client: any IMKTextInput) {
         guard case .suggesting(let session) = inputState else { return }
 
-        let suggestions = session.paths.map { path in
-            path.segments.map { candidates in
-                candidates.first?.surface ?? ""
-            }.joined()
+        let allSurfaces = session.paths.map { path in
+            path.segments.map { $0.first?.surface ?? "" }.joined()
         }
+
+        // 文節区切りが異なっても表層が同じになる候補を除去（挿入順を保持）
+        var seen = Set<String>()
+        let suggestions = allSurfaces.filter { seen.insert($0).inserted }
 
         guard !suggestions.isEmpty else {
             Self.candidateWindow.hide()
             return
         }
 
+        // 選択中パスの表層に対応するインデックスを求める
+        let selectedSurface = allSurfaces[session.selectedPathIndex]
+        let selectedIndex = suggestions.firstIndex(of: selectedSurface) ?? 0
+
         var lineHeightRect = NSRect.zero
         client.attributes(forCharacterIndex: 0, lineHeightRectangle: &lineHeightRect)
 
         Self.candidateWindow.showSuggestions(
             suggestions: suggestions,
-            selectedIndex: session.selectedPathIndex,
+            selectedIndex: selectedIndex,
             cursorRect: lineHeightRect
         )
     }


### PR DESCRIPTION
## Summary

- k-best のサジェスト候補に全く同じ表層文字列が表示される問題を修正
- 文節区切りが異なっていても、各文節の最良候補を繋げた表層が同じになる場合がある
- 表示前に表層文字列で重複排除するよう修正（挿入順を保持）

## Changes

`showSuggestCandidateWindow` 内で候補を表示する前に重複排除を追加:
1. 全パスの表層文字列を先に計算
2. `Set.insert(_:).inserted` でフィルタして挿入順を保ちつつ重複除去
3. 選択中パスの表層に対応するインデックスを正しくマッピング