### PR TITLE
Fix duplicate entries in conversion candidate window

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Converting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Converting.swift
@@ -195,18 +195,26 @@ extension AkazaInputController {
     func showCandidateWindow(client: any IMKTextInput) {
         guard case .converting(let session) = inputState else { return }
 
-        let candidates = session.focusedCandidates
-        guard !candidates.isEmpty else {
+        let allCandidates = session.focusedCandidates
+        guard !allCandidates.isEmpty else {
             Self.candidateWindow.hide()
             return
         }
+
+        // surfaceが同じ候補を除去（挿入順を保持）
+        var seen = Set<String>()
+        let candidates = allCandidates.filter { seen.insert($0.surface).inserted }
+
+        // 選択中候補のsurfaceに対応するインデックスを求める
+        let selectedSurface = allCandidates[session.focusedSelectedIndex].surface
+        let selectedIndex = candidates.firstIndex(where: { $0.surface == selectedSurface }) ?? 0
 
         var lineHeightRect = NSRect.zero
         client.attributes(forCharacterIndex: 0, lineHeightRectangle: &lineHeightRect)
 
         Self.candidateWindow.show(
             candidates: candidates,
-            selectedIndex: session.focusedSelectedIndex,
+            selectedIndex: selectedIndex,
             cursorRect: lineHeightRect
         )
     }


### PR DESCRIPTION
## Summary

- スペース押下後の変換候補ウィンドウに同じ表層文字列の候補が重複して表示される問題を修正
- 同じ読みに対して複数のエントリが同一の surface を持つ場合がある
- 表示前に surface 文字列で重複排除するよう修正（挿入順を保持）

## Changes

`showCandidateWindow` 内で候補を表示する前に重複排除を追加:
1. `Set.insert(_:).inserted` でフィルタして挿入順を保ちつつ重複除去
2. 選択中候補の surface に対応するインデックスを重複排除後のリストで正しくマッピング