### PR TITLE
Fix arrow keys inserting tofu characters in suggesting state

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Suggesting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Suggesting.swift
@@ -20,6 +20,8 @@ extension AkazaInputController {
             return handleEscapeInSuggesting(client: client)
         case 51: // Backspace
             return handleBackspaceInSuggesting(client: client)
+        case 123, 124, 125, 126: // Arrow keys (Left, Right, Down, Up)
+            return true
         default:
             return handleCharacterInSuggesting(event: event, client: client)
         }


### PR DESCRIPTION
## Summary

- `handleSuggestingState` に矢印キー（Left/Right/Up/Down）のケースが未定義だったため、`default` に落ちて `handleCharacterInSuggesting` が呼ばれていた
- 矢印キーの `event.characters` は `\u{F700}` 台のUnicode文字で、`handleCharacterInput` の制御文字チェック（`scalar < 0x20`）をすり抜けてしまい、`composedHiragana` に追加されて豆腐として表示されていた
- 修正: suggesting 状態中の矢印キーはイベントを消費してそのまま `true` を返すようにした

## Test plan

- [ ] ひらがなを入力してサジェスト候補が表示された状態で、矢印キー（↑↓←→）を押しても豆腐が入力されないことを確認