### PR TITLE
Fix Up/Down arrow key navigation in suggesting state

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Suggesting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Suggesting.swift
@@ -20,7 +20,11 @@ extension AkazaInputController {
             return handleEscapeInSuggesting(client: client)
         case 51: // Backspace
             return handleBackspaceInSuggesting(client: client)
-        case 123, 124, 125, 126: // Arrow keys (Left, Right, Down, Up)
+        case 125: // Down arrow
+            return handleNextPathInSuggesting(client: client)
+        case 126: // Up arrow
+            return handlePreviousPathInSuggesting(client: client)
+        case 123, 124: // Left, Right arrow: consume to avoid tofu input
             return true
         default:
             return handleCharacterInSuggesting(event: event, client: client)


### PR DESCRIPTION
## Summary

前の修正（#34）で矢印キー全てを消費するようにしたため、suggesting 状態で矢印キーによる候補選択ができなくなっていた。

- 下矢印（↓）: 次のサジェスト候補に移動
- 上矢印（↑）: 前のサジェスト候補に移動
- 左右矢印（←→）: 豆腐入力を防ぐためイベントを消費するのみ

## Test plan

- [ ] ひらがなを入力してサジェスト候補が表示された状態で、↓/↑ で候補を選択できることを確認
- [ ] ←/→ を押しても豆腐が入力されないことを確認