### PR TITLE
Bump akaza library and model to v2026.220.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,25 @@ Resources/         # アイコン等のリソース
 - akaza-server との通信は非同期で行い、UI スレッドをブロックしないこと
 - akaza-server のクラッシュに備え、変換リクエストのタイムアウトを設定すること
 
+## バージョンアップ手順
+
+akaza ライブラリとモデルを新しいバージョン（例: `vYYYY.MMD.0`）に更新する場合、以下の 2 ファイルを修正する。
+
+1. `akaza-server/Cargo.toml` の `libakaza` タグを更新
+   ```toml
+   libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "vYYYY.MMD.0" }
+   ```
+
+2. `Makefile` の `MODEL_VERSION` を更新
+   ```makefile
+   MODEL_VERSION = vYYYY.MMD.0
+   ```
+
+3. `Cargo.lock` を更新
+   ```sh
+   cargo update -p libakaza
+   ```
+
 ## 関連リポジトリ
 
 - [akaza](https://github.com/akaza-im/akaza) - Rust 製かな漢字変換エンジン (コアライブラリ libakaza)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "libakaza"
 version = "0.1.7"
-source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.218.0#1f51c404ad76c3358d376ddf8d47a45783aeb90b"
+source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.220.0#f00aedf1e027bfbcef93522356759da26752ddef"
 dependencies = [
  "anyhow",
  "cedarwood",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUTDIR = out/
 APP = $(OUTDIR)/Akaza.app
 INSTALL_DIR = $(HOME)/Library/Input Methods
-MODEL_VERSION = v2026.218.0
+MODEL_VERSION = v2026.220.0
 MODEL_DIR = $(OUTDIR)/model/$(MODEL_VERSION)
 MODEL_TARBALL = $(MODEL_DIR)/akaza-default-model.tar.gz
 

--- a/akaza-server/Cargo.toml
+++ b/akaza-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.218.0" }
+libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.220.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"


### PR DESCRIPTION
## Summary

- `akaza-server/Cargo.toml`: libakaza タグを `v2026.218.0` → `v2026.220.0` に更新
- `Makefile`: `MODEL_VERSION` を `v2026.218.0` → `v2026.220.0` に更新
- `Cargo.lock`: `cargo update -p libakaza` で更新
- `CLAUDE.md`: バージョンアップ手順を追記