### PR TITLE
Show model version info in preferences

### DIFF
--- a/Sources/AkazaIME/GeneralSettingsView.swift
+++ b/Sources/AkazaIME/GeneralSettingsView.swift
@@ -2,21 +2,25 @@ import Cocoa
 
 class GeneralSettingsView: NSView {
     private let punctuationPopUp = NSPopUpButton()
+    private let modelVersionLabel = NSTextField(labelWithString: "読み込み中...")
+    private let modelBuildTimestampLabel = NSTextField(labelWithString: "")
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         setupUI()
+        loadModelInfo()
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupUI()
+        loadModelInfo()
     }
 
     private func setupUI() {
-        let label = NSTextField(labelWithString: "句読点スタイル:")
-        label.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(label)
+        let punctuationLabel = NSTextField(labelWithString: "句読点スタイル:")
+        punctuationLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(punctuationLabel)
 
         punctuationPopUp.translatesAutoresizingMaskIntoConstraints = false
         punctuationPopUp.addItems(withTitles: [
@@ -29,13 +33,78 @@ class GeneralSettingsView: NSView {
         addSubview(punctuationPopUp)
 
         NSLayoutConstraint.activate([
-            label.topAnchor.constraint(equalTo: topAnchor, constant: 20),
-            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            punctuationLabel.topAnchor.constraint(equalTo: topAnchor, constant: 20),
+            punctuationLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
 
-            punctuationPopUp.centerYAnchor.constraint(equalTo: label.centerYAnchor),
-            punctuationPopUp.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 8),
+            punctuationPopUp.centerYAnchor.constraint(equalTo: punctuationLabel.centerYAnchor),
+            punctuationPopUp.leadingAnchor.constraint(equalTo: punctuationLabel.trailingAnchor, constant: 8),
             punctuationPopUp.widthAnchor.constraint(greaterThanOrEqualToConstant: 200)
         ])
+
+        setupModelInfoViews(below: punctuationLabel)
+    }
+
+    private func setupModelInfoViews(below aboveView: NSView) {
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separator)
+
+        let modelSectionLabel = NSTextField(labelWithString: "モデル情報")
+        modelSectionLabel.font = NSFont.boldSystemFont(ofSize: NSFont.smallSystemFontSize)
+        modelSectionLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(modelSectionLabel)
+
+        let modelVersionKeyLabel = NSTextField(labelWithString: "バージョン:")
+        modelVersionKeyLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(modelVersionKeyLabel)
+
+        modelVersionLabel.translatesAutoresizingMaskIntoConstraints = false
+        modelVersionLabel.isSelectable = true
+        addSubview(modelVersionLabel)
+
+        let modelBuildKeyLabel = NSTextField(labelWithString: "ビルド日時:")
+        modelBuildKeyLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(modelBuildKeyLabel)
+
+        modelBuildTimestampLabel.translatesAutoresizingMaskIntoConstraints = false
+        modelBuildTimestampLabel.isSelectable = true
+        addSubview(modelBuildTimestampLabel)
+
+        NSLayoutConstraint.activate([
+            separator.topAnchor.constraint(equalTo: aboveView.bottomAnchor, constant: 16),
+            separator.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            separator.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+
+            modelSectionLabel.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 8),
+            modelSectionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+
+            modelVersionKeyLabel.topAnchor.constraint(equalTo: modelSectionLabel.bottomAnchor, constant: 8),
+            modelVersionKeyLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            modelVersionKeyLabel.widthAnchor.constraint(equalToConstant: 80),
+
+            modelVersionLabel.centerYAnchor.constraint(equalTo: modelVersionKeyLabel.centerYAnchor),
+            modelVersionLabel.leadingAnchor.constraint(equalTo: modelVersionKeyLabel.trailingAnchor, constant: 8),
+
+            modelBuildKeyLabel.topAnchor.constraint(equalTo: modelVersionKeyLabel.bottomAnchor, constant: 6),
+            modelBuildKeyLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            modelBuildKeyLabel.widthAnchor.constraint(equalToConstant: 80),
+
+            modelBuildTimestampLabel.centerYAnchor.constraint(equalTo: modelBuildKeyLabel.centerYAnchor),
+            modelBuildTimestampLabel.leadingAnchor.constraint(
+                equalTo: modelBuildKeyLabel.trailingAnchor, constant: 8)
+        ])
+    }
+
+    private func loadModelInfo() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let info = akazaClient.modelInfoSync()
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.modelVersionLabel.stringValue = info?.akazaDataVersion ?? "(不明)"
+                self.modelBuildTimestampLabel.stringValue = info?.buildTimestamp ?? "(不明)"
+            }
+        }
     }
 
     @objc private func punctuationStyleChanged(_ sender: NSPopUpButton) {

--- a/Sources/AkazaIME/JSONRPCClient.swift
+++ b/Sources/AkazaIME/JSONRPCClient.swift
@@ -18,6 +18,16 @@ struct UserDictEntry: Decodable {
     let surfaces: [String]
 }
 
+struct ModelInfo: Decodable {
+    let akazaDataVersion: String?
+    let buildTimestamp: String?
+
+    enum CodingKeys: String, CodingKey {
+        case akazaDataVersion = "akaza_data_version"
+        case buildTimestamp = "build_timestamp"
+    }
+}
+
 class JSONRPCClient {
     private let serverProcess: AkazaServerProcess
     private var nextID = 1
@@ -62,6 +72,16 @@ class JSONRPCClient {
                     self?.handleResponse(lineData)
                 }
             }
+        }
+    }
+
+    func modelInfoSync() -> ModelInfo? {
+        guard let data = sendRequestSync(method: "model_info", params: [:]) else { return nil }
+        do {
+            return try JSONDecoder().decode(ModelInfo.self, from: data)
+        } catch {
+            NSLog("AkazaIME: failed to decode model_info result: \(error)")
+            return nil
         }
     }
 

--- a/akaza-server/src/handler.rs
+++ b/akaza-server/src/handler.rs
@@ -7,6 +7,7 @@ use libakaza::engine::bigram_word_viterbi_engine::BigramWordViterbiEngine;
 use libakaza::graph::candidate::Candidate;
 use libakaza::kana_kanji::base::KanaKanjiDict;
 use libakaza::lm::base::{SystemBigramLM, SystemUnigramLM};
+use libakaza::lm::system_unigram_lm::MarisaSystemUnigramLM;
 use log::{error, info};
 use serde_json::Value;
 
@@ -15,11 +16,20 @@ use crate::jsonrpc::*;
 pub struct Handler<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> {
     engine: BigramWordViterbiEngine<U, B, KD>,
     dict_path: String,
+    model_dir: String,
 }
 
 impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD> {
-    pub fn new(engine: BigramWordViterbiEngine<U, B, KD>, dict_path: String) -> Self {
-        Self { engine, dict_path }
+    pub fn new(
+        engine: BigramWordViterbiEngine<U, B, KD>,
+        dict_path: String,
+        model_dir: String,
+    ) -> Self {
+        Self {
+            engine,
+            dict_path,
+            model_dir,
+        }
     }
 
     pub fn handle_request(&mut self, line: &str) -> String {
@@ -41,6 +51,7 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
             "user_dict_list" => self.handle_user_dict_list(&request),
             "user_dict_add" => self.handle_user_dict_add(&request),
             "user_dict_delete" => self.handle_user_dict_delete(&request),
+            "model_info" => self.handle_model_info(&request),
             _ => Response::error(
                 request.id,
                 METHOD_NOT_FOUND,
@@ -285,6 +296,28 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
                     request.id.clone(),
                     INTERNAL_ERROR,
                     "Failed to access user data".to_string(),
+                )
+            }
+        }
+    }
+
+    fn handle_model_info(&self, request: &Request) -> Response {
+        let unigram_path = format!("{}/unigram.model", self.model_dir);
+        match MarisaSystemUnigramLM::load(&unigram_path) {
+            Ok(lm) => {
+                let metadata = lm.metadata();
+                let result = ModelInfoResult {
+                    akaza_data_version: metadata.akaza_data_version,
+                    build_timestamp: metadata.build_timestamp,
+                };
+                Response::success(request.id.clone(), serde_json::to_value(result).unwrap())
+            }
+            Err(e) => {
+                error!("model_info: failed to load unigram model: {}", e);
+                Response::error(
+                    request.id.clone(),
+                    INTERNAL_ERROR,
+                    format!("Failed to load model: {}", e),
                 )
             }
         }

--- a/akaza-server/src/jsonrpc.rs
+++ b/akaza-server/src/jsonrpc.rs
@@ -60,6 +60,12 @@ pub struct UserDictEntry {
 }
 
 #[derive(Debug, Serialize)]
+pub struct ModelInfoResult {
+    pub akaza_data_version: Option<String>,
+    pub build_timestamp: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
 pub struct CandidateResult {
     pub surface: String,
     pub yomi: String,

--- a/akaza-server/src/main.rs
+++ b/akaza-server/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
     ));
 
     let config = EngineConfig {
-        model: model_dir,
+        model: model_dir.clone(),
         dicts: vec![],
         dict_cache: true,
         reranking_weights: ReRankingWeights::default(),
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
         .unwrap()
         .to_string();
 
-    let mut handler = handler::Handler::new(engine, dict_path);
+    let mut handler = handler::Handler::new(engine, dict_path, model_dir.clone());
 
     let stdin = io::stdin();
     let mut stdout = io::stdout();


### PR DESCRIPTION
## Summary

libakaza v2026.220.0 でモデルファイルにバージョン情報が埋め込まれるようになった（akaza #487）のに対応し、設定画面からモデル情報を確認できるようにした。

**akaza-server の変更:**
- `model_info` JSON-RPC メソッドを追加
  - `unigram.model` から `akaza_data_version`（モデルバージョン）と `build_timestamp`（ビルド日時）を読み取って返す

**Swift の変更:**
- `JSONRPCClient` に `modelInfoSync()` を追加
- 設定画面の「一般」タブにモデル情報セクションを追加（バージョン・ビルド日時）
  - 設定画面を開いた時に非同期で取得・表示

## Test plan

- [ ] 設定画面を開いてモデル情報セクションにバージョンとビルド日時が表示されることを確認