### PR TITLE
Fix Enter in suggesting state to commit original hiragana

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Suggesting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Suggesting.swift
@@ -93,9 +93,8 @@ extension AkazaInputController {
 
     func commitSuggestingText(client: any IMKTextInput) {
         guard case .suggesting(let session) = inputState else { return }
-        let text = session.displayText
+        let text = session.originalHiragana
         client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
-        akazaClient.learnSync(candidates: session.selectedCandidates)
         resetToComposing()
     }
 


### PR DESCRIPTION
## Summary

composing 状態で Space を押さずに Enter を押した場合、k-best サジェストの先頭候補が入力されてしまっていた問題を修正。

- suggesting 状態で Enter（またはフォーカス喪失）した際、`session.displayText`（サジェスト候補）ではなく `session.originalHiragana` を入力するよう変更
- Tab でサジェスト候補を選んだ場合でも、Enter はひらがなを確定する（変換して確定したい場合は Space → Enter）

## Test plan

- [ ] ひらがなを入力してサジェストが表示された状態で Space を押さずに Enter を押すと、ひらがながそのまま入力されることを確認