### PR TITLE
Fix backspace to delete romaji sequence as single character

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -137,7 +137,13 @@ class AkazaInputController: IMKInputController {
         // Restore from input history if available
         guard !inputHistory.isEmpty else { return false }
 
-        let snapshot = inputHistory.removeLast()
+        // Skip snapshots with non-empty romajiBuffer to treat multi-key romaji sequences
+        // (e.g. "ge" → "げ") as a single character for backspace purposes.
+        var snapshot: ComposingSnapshot
+        repeat {
+            snapshot = inputHistory.removeLast()
+        } while !snapshot.romajiBuffer.isEmpty && !inputHistory.isEmpty
+
         composedHiragana = snapshot.composedHiragana
         romajiConverter.setBuffer(snapshot.romajiBuffer)
         updateComposingMarkedText(client: client)


### PR DESCRIPTION
## Summary

composing 中に "hoge" などと入力してバックスペースを押すと "ほg" になってしまう問題を修正。

**原因:** 文字入力ごとにスナップショットを保存しているため、BS で1つ前のスナップショット `{composedHiragana="ほ", romajiBuffer="g"}` に戻ってしまい、"ほg" が表示されていた。

**修正:** BS 時に `romajiBuffer` が空のスナップショットが見つかるまでスキップするようにした。これにより "ge" → "げ" のようなマルチキーのローマ字シーケンスを1文字として扱えるようになった。

例:
- "hoge" → BS → "ほ"（修正前: "ほg"）
- "hog" → BS → "ほ"
- "ほ" → BS → ""

## Test plan

- [ ] "hoge" と入力して BS → "ほ" になることを確認
- [ ] "ho" と入力して BS → "" になることを確認
- [ ] "ほge" の状態で BS → "ほ" になることを確認