### PR TITLE
Add lookup_unigram and lookup_bigram JSON-RPC methods

### DIFF
--- a/akaza-server/Cargo.toml
+++ b/akaza-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.220.0" }
+libakaza = { git = "https://github.com/akaza-im/akaza.git", branch = "feat/lookup-api" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/akaza-server/src/handler.rs
+++ b/akaza-server/src/handler.rs
@@ -7,6 +7,7 @@ use libakaza::engine::bigram_word_viterbi_engine::BigramWordViterbiEngine;
 use libakaza::graph::candidate::Candidate;
 use libakaza::kana_kanji::base::KanaKanjiDict;
 use libakaza::lm::base::{SystemBigramLM, SystemUnigramLM};
+use libakaza::lm::system_bigram::MarisaSystemBigramLM;
 use libakaza::lm::system_unigram_lm::MarisaSystemUnigramLM;
 use log::{error, info};
 use serde_json::Value;
@@ -17,6 +18,8 @@ pub struct Handler<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> {
     engine: BigramWordViterbiEngine<U, B, KD>,
     dict_path: String,
     model_dir: String,
+    unigram_lm: MarisaSystemUnigramLM,
+    bigram_lm: MarisaSystemBigramLM,
 }
 
 impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD> {
@@ -24,11 +27,15 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
         engine: BigramWordViterbiEngine<U, B, KD>,
         dict_path: String,
         model_dir: String,
+        unigram_lm: MarisaSystemUnigramLM,
+        bigram_lm: MarisaSystemBigramLM,
     ) -> Self {
         Self {
             engine,
             dict_path,
             model_dir,
+            unigram_lm,
+            bigram_lm,
         }
     }
 
@@ -52,6 +59,8 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
             "user_dict_add" => self.handle_user_dict_add(&request),
             "user_dict_delete" => self.handle_user_dict_delete(&request),
             "model_info" => self.handle_model_info(&request),
+            "lookup_unigram" => self.handle_lookup_unigram(&request),
+            "lookup_bigram" => self.handle_lookup_bigram(&request),
             _ => Response::error(
                 request.id,
                 METHOD_NOT_FOUND,
@@ -299,6 +308,81 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
                 )
             }
         }
+    }
+
+    fn handle_lookup_unigram(&self, request: &Request) -> Response {
+        let params: LookupUnigramParams = match serde_json::from_value(request.params.clone()) {
+            Ok(p) => p,
+            Err(e) => {
+                return Response::error(
+                    request.id.clone(),
+                    INVALID_PARAMS,
+                    format!("Invalid params: {}", e),
+                );
+            }
+        };
+
+        let result = match self.unigram_lm.lookup(&params.word) {
+            Some((word_id, score)) => LookupUnigramResult {
+                found: true,
+                word_id: Some(word_id),
+                score: Some(score),
+            },
+            None => LookupUnigramResult {
+                found: false,
+                word_id: None,
+                score: None,
+            },
+        };
+        Response::success(request.id.clone(), serde_json::to_value(result).unwrap())
+    }
+
+    fn handle_lookup_bigram(&self, request: &Request) -> Response {
+        let params: LookupBigramParams = match serde_json::from_value(request.params.clone()) {
+            Ok(p) => p,
+            Err(e) => {
+                return Response::error(
+                    request.id.clone(),
+                    INVALID_PARAMS,
+                    format!("Invalid params: {}", e),
+                );
+            }
+        };
+
+        let (word1_id, word2_id) = match (
+            self.unigram_lm.lookup(&params.word1),
+            self.unigram_lm.lookup(&params.word2),
+        ) {
+            (Some((id1, _)), Some((id2, _))) => (id1, id2),
+            _ => {
+                let result = LookupBigramResult {
+                    found: false,
+                    word1_id: self.unigram_lm.lookup(&params.word1).map(|(id, _)| id),
+                    word2_id: self.unigram_lm.lookup(&params.word2).map(|(id, _)| id),
+                    score: None,
+                };
+                return Response::success(
+                    request.id.clone(),
+                    serde_json::to_value(result).unwrap(),
+                );
+            }
+        };
+
+        let result = match self.bigram_lm.lookup(word1_id, word2_id) {
+            Some(score) => LookupBigramResult {
+                found: true,
+                word1_id: Some(word1_id),
+                word2_id: Some(word2_id),
+                score: Some(score),
+            },
+            None => LookupBigramResult {
+                found: false,
+                word1_id: Some(word1_id),
+                word2_id: Some(word2_id),
+                score: None,
+            },
+        };
+        Response::success(request.id.clone(), serde_json::to_value(result).unwrap())
     }
 
     fn handle_model_info(&self, request: &Request) -> Response {

--- a/akaza-server/src/jsonrpc.rs
+++ b/akaza-server/src/jsonrpc.rs
@@ -65,6 +65,32 @@ pub struct ModelInfoResult {
     pub build_timestamp: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct LookupUnigramParams {
+    pub word: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LookupUnigramResult {
+    pub found: bool,
+    pub word_id: Option<i32>,
+    pub score: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LookupBigramParams {
+    pub word1: String,
+    pub word2: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LookupBigramResult {
+    pub found: bool,
+    pub word1_id: Option<i32>,
+    pub word2_id: Option<i32>,
+    pub score: Option<f32>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct CandidateResult {
     pub surface: String,

--- a/akaza-server/src/main.rs
+++ b/akaza-server/src/main.rs
@@ -9,6 +9,8 @@ use anyhow::Result;
 use libakaza::config::EngineConfig;
 use libakaza::engine::bigram_word_viterbi_engine::BigramWordViterbiEngineBuilder;
 use libakaza::graph::reranking::ReRankingWeights;
+use libakaza::lm::system_bigram::MarisaSystemBigramLM;
+use libakaza::lm::system_unigram_lm::MarisaSystemUnigramLM;
 use libakaza::user_side_data::user_data::UserData;
 use log::info;
 
@@ -44,6 +46,9 @@ fn main() -> Result<()> {
 
     info!("Engine initialized successfully");
 
+    let unigram_lm = MarisaSystemUnigramLM::load(&format!("{}/unigram.model", model_dir))?;
+    let bigram_lm = MarisaSystemBigramLM::load(&format!("{}/bigram.model", model_dir))?;
+
     let basedir = xdg::BaseDirectories::with_prefix("akaza")?;
     let dict_path = basedir
         .place_data_file(Path::new("SKK-JISYO.user"))?
@@ -51,7 +56,8 @@ fn main() -> Result<()> {
         .unwrap()
         .to_string();
 
-    let mut handler = handler::Handler::new(engine, dict_path, model_dir.clone());
+    let mut handler =
+        handler::Handler::new(engine, dict_path, model_dir.clone(), unigram_lm, bigram_lm);
 
     let stdin = io::stdin();
     let mut stdout = io::stdout();


### PR DESCRIPTION
## Summary

unigram/bigram モデルに特定のワードが含まれているかを問い合わせる JSON-RPC メソッドを追加。変換候補に出ない単語のデバッグに使用できる。

**新メソッド:**

`lookup_unigram` — unigram に word が含まれているか検索
```json
// request
{"method": "lookup_unigram", "params": {"word": "耐障害性/たいしょうがいせい"}}
// response (未登録の場合)
{"result": {"found": false, "word_id": null, "score": null}}
// response (登録済みの場合)
{"result": {"found": true, "word_id": 416662, "score": 5.12}}
```

`lookup_bigram` — bigram に (word1, word2) のエントリが含まれているか検索
```json
// request
{"method": "lookup_bigram", "params": {"word1": "対象外/たいしょうがい", "word2": "性/せい"}}
// response
{"result": {"found": false, "word1_id": 416662, "word2_id": 26612, "score": null}}
```

**実装:**
- Handler に `MarisaSystemUnigramLM` / `MarisaSystemBigramLM` を起動時にキャッシュ
- akaza#492 の lookup API を利用（libakaza への依存を `feat/lookup-api` ブランチに向けている）
- akaza#492 がマージされたら tag に戻す

## Test plan

- [ ] `lookup_unigram` で未登録語が `found: false` になることを確認
- [ ] `lookup_unigram` で登録済み語が `found: true` でスコア付きになることを確認
- [ ] `lookup_bigram` で bigram スコアを確認できることを確認