### PR TITLE
Download SKK-JISYO.L on first launch and load it as dictionary

### DIFF
--- a/Sources/AkazaIME/AkazaServerProcess.swift
+++ b/Sources/AkazaIME/AkazaServerProcess.swift
@@ -1,5 +1,16 @@
 import Cocoa
 
+private let skkJisyoLURL = "https://raw.githubusercontent.com/skk-dev/dict/master/SKK-JISYO.L"
+
+private func skkJisyoLPath() -> URL? {
+    guard let xdgData = ProcessInfo.processInfo.environment["XDG_DATA_HOME"]
+        .map({ URL(fileURLWithPath: $0) })
+        ?? Optional(FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".local/share"))
+    else { return nil }
+    return xdgData.appendingPathComponent("akaza/SKK-JISYO.L")
+}
+
 class AkazaServerProcess {
     private var process: Process?
     private(set) var stdinPipe: Pipe?
@@ -9,6 +20,44 @@ class AkazaServerProcess {
     private var shouldRestart = true
 
     var onRestart: (() -> Void)?
+
+    func downloadSKKDictIfNeeded(completion: @escaping () -> Void) {
+        guard let dest = skkJisyoLPath() else {
+            completion()
+            return
+        }
+        guard !FileManager.default.fileExists(atPath: dest.path) else {
+            completion()
+            return
+        }
+
+        NSLog("AkazaIME: SKK-JISYO.L not found, downloading...")
+        let dirURL = dest.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
+        guard let url = URL(string: skkJisyoLURL) else {
+            completion()
+            return
+        }
+        URLSession.shared.downloadTask(with: url) { tmpURL, _, error in
+            if let error = error {
+                NSLog("AkazaIME: failed to download SKK-JISYO.L: \(error)")
+                completion()
+                return
+            }
+            guard let tmpURL = tmpURL else {
+                completion()
+                return
+            }
+            do {
+                try FileManager.default.moveItem(at: tmpURL, to: dest)
+                NSLog("AkazaIME: SKK-JISYO.L downloaded to \(dest.path)")
+            } catch {
+                NSLog("AkazaIME: failed to save SKK-JISYO.L: \(error)")
+            }
+            completion()
+        }.resume()
+    }
 
     func start() {
         let serverPath = Bundle.main.bundlePath + "/Contents/MacOS/akaza-server"

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -39,8 +39,15 @@ _ = server // IMKServer を保持
 
 let akazaServerProcess = AkazaServerProcess()
 let akazaClient = JSONRPCClient(serverProcess: akazaServerProcess)
-akazaServerProcess.start()
-akazaClient.startReaderLoop()
+
+// SKK-JISYO.L がなければバックグラウンドでダウンロードしてから起動
+// 既にある場合はそのまま即起動
+akazaServerProcess.downloadSKKDictIfNeeded {
+    DispatchQueue.main.async {
+        akazaServerProcess.start()
+        akazaClient.startReaderLoop()
+    }
+}
 
 NSLog("AkazaIME: IMKServer created successfully")
 NSApplication.shared.run()

--- a/akaza-server/src/main.rs
+++ b/akaza-server/src/main.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use libakaza::config::EngineConfig;
+use libakaza::config::{DictConfig, DictEncoding, DictUsage, EngineConfig};
 use libakaza::engine::bigram_word_viterbi_engine::BigramWordViterbiEngineBuilder;
 use libakaza::graph::reranking::ReRankingWeights;
 use libakaza::user_side_data::user_data::UserData;
@@ -31,9 +31,22 @@ fn main() -> Result<()> {
         UserData::load_from_default_path().unwrap_or_default(),
     ));
 
+    let mut dicts: Vec<DictConfig> = Vec::new();
+    if let Ok(basedir) = xdg::BaseDirectories::with_prefix("akaza") {
+        if let Some(path) = basedir.find_data_file("SKK-JISYO.L") {
+            info!("Found SKK-JISYO.L: {}", path.display());
+            dicts.push(DictConfig {
+                path: path.to_string_lossy().to_string(),
+                encoding: DictEncoding::EucJp,
+                dict_type: libakaza::config::DictType::SKK,
+                usage: DictUsage::Normal,
+            });
+        }
+    }
+
     let config = EngineConfig {
         model: model_dir.clone(),
-        dicts: vec![],
+        dicts,
         dict_cache: true,
         reranking_weights: ReRankingWeights::default(),
     };


### PR DESCRIPTION
## Summary

初回起動時に SKK-JISYO.L を自動ダウンロードし、変換辞書として使えるようにする。

**ライセンス対応:**
- SKK-JISYO.L は GPLv2 のため App Bundle に同梱しない
- ユーザーの初回起動時にダウンロードすることで MIT ライセンスのコードと分離

**変更内容:**

`AkazaServerProcess.swift`:
- `downloadSKKDictIfNeeded()` を追加
- `~/.local/share/akaza/SKK-JISYO.L` が存在しない場合、skk-dev/dict から非同期ダウンロード

`main.swift`:
- 起動時に `downloadSKKDictIfNeeded` を呼び出し、完了後に akaza-server を起動（ファイルが既にある場合は即起動）

`akaza-server/src/main.rs`:
- 起動時に `~/.local/share/akaza/SKK-JISYO.L` が存在すれば EUC-JP 辞書として `EngineConfig.dicts` に追加

## Test plan

- [ ] 初回起動時に `~/.local/share/akaza/SKK-JISYO.L` がダウンロードされることを確認
- [ ] 「耐障害性」など SKK-JISYO.L にある単語が変換候補に出ることを確認
- [ ] 2回目以降の起動では再ダウンロードされず即起動することを確認