### PR TITLE
Update akaza to v2026.224.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,8 +419,8 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libakaza"
-version = "2026.220.3"
-source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.220.3#4959f258f36b8495d21044de627eb6475c3978e5"
+version = "2026.224.0"
+source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.224.0#7c93f16d58da78663bc61ecbe8eeb9de85821228"
 dependencies = [
  "anyhow",
  "cedarwood",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUTDIR = out/
 APP = $(OUTDIR)/Akaza.app
 INSTALL_DIR = $(HOME)/Library/Input Methods
-MODEL_VERSION = v2026.220.3
+MODEL_VERSION = v2026.224.0
 MODEL_DIR = $(OUTDIR)/model/$(MODEL_VERSION)
 MODEL_TARBALL = $(MODEL_DIR)/akaza-default-model.tar.gz
 

--- a/akaza-server/Cargo.toml
+++ b/akaza-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.220.3" }
+libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.224.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"


### PR DESCRIPTION
## Summary

- `libakaza` タグを `v2026.220.3` → `v2026.224.0` に更新
- `MODEL_VERSION` を `v2026.224.0` に更新
- `Cargo.lock` を更新