### PR TITLE
fix: install *.model.scores files for bigram/skip-bigram

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ install: build download-model
 	cp target/release/akaza-server $(APP)/Contents/MacOS/
 	cp -r resources/* $(APP)/Contents/Resources/
 	cp $(MODEL_DIR)/akaza-default-model/*.model $(APP)/Contents/Resources/model/
+	cp $(MODEL_DIR)/akaza-default-model/*.model.scores $(APP)/Contents/Resources/model/
 	cp $(MODEL_DIR)/akaza-default-model/SKK-JISYO.* $(APP)/Contents/Resources/model/
 	cp -a $(APP) "$(INSTALL_DIR)/"
 


### PR DESCRIPTION
## Summary

- v2026.225.2 から `bigram.model` / `skip_bigram.model` のスコアが別ファイル (`.scores`) に分離された
- Makefile の install ステップで `*.model.scores` がコピーされておらず、akaza-server が起動失敗していた
- `*.model.scores` もコピーするように修正

## 関連コミット

https://github.com/akaza-im/akaza/commit/9a02f305c4a4dc8c92f710466f8f1073e7d25f03