### PR TITLE
perf: make suggestMaxPaths configurable, default to 5

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -259,7 +259,7 @@ class AkazaInputController: IMKInputController {
         guard yomi != latestSuggestYomi else { return }
 
         latestSuggestYomi = yomi
-        let requestID = akazaClient.convertKBestAsync(yomi: yomi, maxPaths: 9) { [weak self] paths in
+        let requestID = akazaClient.convertKBestAsync(yomi: yomi, maxPaths: Settings.shared.suggestMaxPaths) { [weak self] paths in
             guard let self = self else { return }
             guard case .composing = self.inputState else { return }
             guard let paths = paths, !paths.isEmpty else { return }

--- a/Sources/AkazaIME/Settings.swift
+++ b/Sources/AkazaIME/Settings.swift
@@ -18,4 +18,14 @@ class Settings {
         get { defaults.stringArray(forKey: "additionalDictPaths") ?? [] }
         set { defaults.set(newValue, forKey: "additionalDictPaths") }
     }
+
+    // サジェスト候補の最大パス数。k=9 は速度が遅いため k=5 をデフォルトとする (2026-02-26)
+    // defaults write com.github.tokuhirom.inputmethod.Japanese.Akaza suggestMaxPaths -int 5
+    var suggestMaxPaths: Int {
+        get {
+            let value = defaults.integer(forKey: "suggestMaxPaths")
+            return value > 0 ? value : 5
+        }
+        set { defaults.set(newValue, forKey: "suggestMaxPaths") }
+    }
 }


### PR DESCRIPTION
## Summary

- サジェスト候補の最大パス数 (`k`) をハードコードから `Settings` 経由の設定値に変更
- デフォルトを 9 → 5 に変更（k=9 はサーバー処理が遅く、長文入力時のディレイの原因になっていた）
- `UserDefaults` に保存されるため、以下のコマンドで変更可能:

```sh
defaults write com.github.tokuhirom.inputmethod.Japanese.Akaza suggestMaxPaths -int 5
```

## 背景

変換精度の向上により一文まるごと入力できるようになったが、k-best および skip-gram の導入で変換速度が劣化し、長文入力時のディレイが気になるようになった。k=9 は候補数として過剰であり、k=5 で十分な精度が得られる。

## Test plan

- [ ] 長文入力時のサジェスト表示速度が改善されること
- [ ] `suggestMaxPaths` を未設定の場合、デフォルト値 5 が使われること
- [ ] `defaults write` で値を変更した後、再起動でその値が反映されること