### PR TITLE
fix: 子音で終わる入力後のSpace+Enterで候補ウィンドウが消えない問題を修正

### DIFF
--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -93,6 +93,7 @@ class AkazaInputController: IMKInputController {
             composedHiragana = text
             clearInputHistory()
             updateComposingMarkedText(client: client)
+            Self.candidateWindow.hide()
             return true
         }
 
@@ -115,12 +116,14 @@ class AkazaInputController: IMKInputController {
         guard !text.isEmpty else {
             composedHiragana = ""
             clearInputHistory()
+            Self.candidateWindow.hide()
             return true
         }
 
         client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
         composedHiragana = ""
         clearInputHistory()
+        Self.candidateWindow.hide()
         return true
     }
 


### PR DESCRIPTION
## 問題

「narisouw」「hogek」のように子音で終わる入力をして Space+Enter した際、変換中の候補ウィンドウが消えない。

## 原因

`.suggesting` 状態（候補ウィンドウ表示中）で子音を入力すると `handleCharacterInSuggesting` が `.composing` に戻るが、候補ウィンドウは意図的に隠さない設計になっている（"新しいサジェストで更新される" ため）。

その後の処理で候補ウィンドウを隠すべきタイミングが2箇所抜けていた：

1. **`handleSpaceInComposing` の変換失敗パス**：`convertSync(yomi:)` が子音混じりの yomi（例：`"なりそうw"`）で失敗した場合、`.composing` に留まって `return true` していたが `candidateWindow.hide()` が呼ばれていなかった。

2. **`handleEnterInComposing`**：composing 状態でのコミット（Enter キー）に `candidateWindow.hide()` が一切なかった。`commitConvertingText` / `commitSuggestingText` は `resetToComposing()` 経由で必ず隠しているが、composing 状態からのコミットパスだけ漏れていた。

## 修正

上記2箇所に `Self.candidateWindow.hide()` を追加。