### PR TITLE
chore: setup tagpr for automated releases

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Check formatting
       run: cargo fmt --check
     - name: Clippy

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Build
       run: swift build -c release

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,28 @@
+name: tagpr
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        with:
+          app-id: ${{ vars.TAGPR_APP_ID }}
+          private-key: ${{ secrets.TAGPR_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: Songmu/tagpr@b3fb89424646b06c8aa460f50307c60b6a541425 # v1.17.1
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,7 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial tag and release.
+[tagpr]
+	vPrefix = true
+	releaseBranch = main
+	versionFile = -
+	calendarVersioning = true


### PR DESCRIPTION
## 概要

tagpr によるタグ・リリース自動管理のセットアップ。

## 変更内容

- `.github/workflows/tagpr.yml` を追加（GitHub App トークン使用）
- `.tagpr` 設定ファイルを追加（カレンダーバージョニング有効）
- 既存 workflow（rust.yml / swift.yml）のアクションバージョンを pinact でピン留め

## 事前準備

動作には GitHub リポジトリ側での設定が必要：
- `vars.TAGPR_APP_ID` — GitHub App の App ID
- `secrets.TAGPR_APP_PRIVATE_KEY` — GitHub App の秘密鍵