### PR TITLE
chore: add release workflow and universal binary build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Select Xcode 16.2
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+
+      - name: Import Code-Signing Certificates
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3.0.0
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
+
+      - name: Install Rust 1.93.0
+        run: |
+          rustup install 1.93.0
+          rustup default 1.93.0
+
+      - name: Build universal binary
+        run: make build-universal
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Bundle app
+        run: make bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Sign app bundle
+        run: |
+          APP="out/Akaza.app"
+          SIGN_IDENTITY="Developer ID Application"
+          codesign --force --options runtime --sign "$SIGN_IDENTITY" --timestamp \
+            "$APP/Contents/MacOS/akaza-server"
+          codesign --force --options runtime --sign "$SIGN_IDENTITY" --timestamp \
+            "$APP/Contents/MacOS/AkazaIME"
+          codesign --force --options runtime --sign "$SIGN_IDENTITY" --timestamp \
+            "$APP"
+
+      - name: Create zip for notarization
+        run: ditto -c -k --keepParent out/Akaza.app Akaza-notarize.zip
+
+      - name: Notarize
+        run: |
+          SUBMISSION_ID=$(xcrun notarytool submit Akaza-notarize.zip \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            --wait \
+            --output-format json | jq -r '.id')
+          echo "Submission ID: $SUBMISSION_ID"
+          xcrun notarytool log "$SUBMISSION_ID" \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --password "${{ secrets.APPLE_ID_PASSWORD }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}"
+
+      - name: Staple notarization ticket
+        run: xcrun stapler staple out/Akaza.app
+
+      - name: Create release zip
+        run: ditto -c -k --keepParent out/Akaza.app Akaza.zip
+
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.ref_name }}" Akaza.zip --clobber

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,28 @@ MODEL_VERSION = v2026.303.0
 MODEL_DIR = $(OUTDIR)/model/$(MODEL_VERSION)
 MODEL_TARBALL = $(MODEL_DIR)/akaza-default-model.tar.gz
 
-.PHONY: all build install clean download-model
+.PHONY: all build build-universal bundle install clean download-model
 
 all: build
 
 build:
 	swift build -c release
 	cargo build --release
+
+build-universal:
+	swift build -c release --arch arm64
+	swift build -c release --arch x86_64
+	lipo -create \
+		.build/arm64-apple-macosx/release/AkazaIME \
+		.build/x86_64-apple-macosx/release/AkazaIME \
+		-output .build/release/AkazaIME
+	rustup target add aarch64-apple-darwin x86_64-apple-darwin
+	cargo build --release --target aarch64-apple-darwin
+	cargo build --release --target x86_64-apple-darwin
+	lipo -create \
+		target/aarch64-apple-darwin/release/akaza-server \
+		target/x86_64-apple-darwin/release/akaza-server \
+		-output target/release/akaza-server
 
 download-model:
 	@if [ ! -f "$(MODEL_DIR)/akaza-default-model/unigram.model" ]; then \
@@ -26,10 +41,11 @@ download-model:
 		echo "Model already downloaded."; \
 	fi
 
-install: build download-model
+# .app バンドルを out/ に組み立てる（ビルド済みバイナリを使用）
+bundle: download-model
+	rm -rf $(APP)
 	mkdir -p $(APP)/Contents/MacOS
 	mkdir -p $(APP)/Contents/Resources/model
-	rm -rf "$(INSTALL_DIR)/Akaza.app"
 	cp Info.plist $(APP)/Contents/
 	cp .build/release/AkazaIME $(APP)/Contents/MacOS/
 	cp target/release/akaza-server $(APP)/Contents/MacOS/
@@ -37,6 +53,9 @@ install: build download-model
 	cp $(MODEL_DIR)/akaza-default-model/*.model $(APP)/Contents/Resources/model/
 	cp $(MODEL_DIR)/akaza-default-model/*.model.scores $(APP)/Contents/Resources/model/
 	cp $(MODEL_DIR)/akaza-default-model/SKK-JISYO.* $(APP)/Contents/Resources/model/
+
+install: build bundle
+	rm -rf "$(INSTALL_DIR)/Akaza.app"
 	cp -a $(APP) "$(INSTALL_DIR)/"
 
 clean:


### PR DESCRIPTION
## Summary

タグプッシュ時に自動ビルド・署名・公証・リリースアップロードを行う GitHub Actions ワークフローを追加。

## ワークフローの流れ

1. コード署名証明書をインポート
2. `make build-universal` — Swift (SPM) + Rust を arm64/x86_64 両方ビルドして `lipo` で Universal Binary に統合
3. `make bundle` — モデルダウンロード + `out/Akaza.app` を組み立て
4. `codesign` — 各バイナリとバンドルに Developer ID Application で署名
5. `xcrun notarytool` — Apple に公証申請（`--wait` で完了まで待機）
6. `xcrun stapler staple` — 公証チケットをバンドルに埋め込み
7. `ditto` で ZIP 化して `gh release upload` でリリースに添付

## Makefile の変更

- `build-universal` ターゲットを追加（arm64 + x86_64 + lipo）
- `bundle` ターゲットを追加（`.app` の組み立てのみ、インストールなし）
- `install` を `build bundle` に依存するよう整理

## 必要な GitHub Secrets

| Secret | 内容 |
|--------|------|
| `CERTIFICATES_P12` | Developer ID 証明書の p12 を base64 エンコードしたもの |
| `CERTIFICATES_P12_PASSWORD` | p12 のパスワード |
| `APPLE_ID` | Apple ID メールアドレス |
| `APPLE_ID_PASSWORD` | App-specific password |
| `APPLE_TEAM_ID` | Apple Developer Team ID |