### PR TITLE
update akaza to v2026.404.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,8 +538,8 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libakaza"
-version = "2026.313.0"
-source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.313.0#1f9716e95b177a6e21457cae5a4d6abef48ec06c"
+version = "2026.404.0"
+source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.404.0#842ea53164eef6fe647e3aa4844c3de58b60a295"
 dependencies = [
  "aes",
  "anyhow",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUTDIR = out/
 APP = $(OUTDIR)/Akaza.app
 INSTALL_DIR = $(HOME)/Library/Input Methods
-MODEL_VERSION = v2026.313.0
+MODEL_VERSION = v2026.404.0
 MODEL_DIR = $(OUTDIR)/model/$(MODEL_VERSION)
 MODEL_TARBALL = $(MODEL_DIR)/akaza-default-model.tar.gz
 

--- a/akaza-server/Cargo.toml
+++ b/akaza-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.313.0" }
+libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.404.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"


### PR DESCRIPTION
## Summary
- libakaza と akaza-default-model を v2026.313.0 → v2026.404.0 に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)