### PR TITLE
fix: throttle learn disk writes to avoid macOS resource limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,61 @@ Resources/         # アイコン等のリソース
 - akaza-server との通信は非同期で行い、UI スレッドをブロックしないこと
 - akaza-server のクラッシュに備え、変換リクエストのタイムアウトを設定すること
 
+### 既知の問題: macOS ディスク書き込み制限による強制終了
+
+macOS は 1 プロセスのディスク書き込み量を 86400 秒あたり約 2147 MB（約 24.86 KB/s）に制限しており、超過すると OS がプロセスを強制終了する。
+
+**原因**: `learn` リクエスト（変換確定のたびに発火）で `write_user_files()` を毎回呼ぶと、unigram/bigram/skip-bigram の 3 ファイル（合計 ~1.5 MB）を毎回 AES 暗号化してフルで書き直すため、長時間使用で制限を超える。
+
+**対処**: `akaza-server/src/handler.rs` の `handle_learn` は 5 分に 1 回だけ書き込み、シャットダウン時に必ず flush する実装になっている（`FLUSH_INTERVAL = 300s`）。60 秒では 24 時間フル稼働時に制限ギリギリになるため 5 分を選択。
+
+## ログ・クラッシュ調査手順
+
+### 1. クラッシュレポートを確認する
+
+```sh
+# ユーザークラッシュレポート
+ls ~/Library/Logs/DiagnosticReports/ | grep -iE "akaza|Akaza"
+
+# システムクラッシュレポート（強制終了・リソース超過含む）
+ls /Library/Logs/DiagnosticReports/ | grep -iE "akaza|Akaza"
+```
+
+ファイル拡張子の見方:
+- `.ips` — クラッシュ（Segfault 等）
+- `.diag` — リソース超過による強制終了（disk writes, CPU, memory）
+
+`.diag` の `Event:` 行で何が原因かわかる（例: `disk writes`）。
+
+### 2. プロセス稼働状況を確認する
+
+```sh
+ps aux | grep -i akaza | grep -v grep
+```
+
+### 3. AkazaIME の NSLog を確認する
+
+```sh
+# 直近 1 時間
+log show --last 1h --predicate 'process CONTAINS "Akaza"' --style compact
+
+# リアルタイム監視
+log stream --predicate 'process CONTAINS "Akaza"' --style compact
+```
+
+akaza-server は stderr にログを出力している（`env_logger`）。
+Swift 側の NSLog は unified logging に流れる。
+
+### 4. akaza-server の stderr をリアルタイムで見る
+
+akaza-server 単体を起動して直接 stderr を確認する。
+
+```sh
+MODEL="$HOME/Library/Input Methods/Akaza.app/Contents/Resources/model"
+SERVER="$HOME/Library/Input Methods/Akaza.app/Contents/MacOS/akaza-server"
+"$SERVER" "$MODEL" 2>&1 >/dev/null
+```
+
 ## バージョンアップ手順
 
 akaza ライブラリとモデルを新しいバージョン（例: `vYYYY.MMD.0`）に更新する場合、以下の 2 ファイルを修正する。

--- a/akaza-server/src/handler.rs
+++ b/akaza-server/src/handler.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::ops::Range;
+use std::time::{Duration, Instant};
 
 use libakaza::dict::skk::write::write_skk_dict;
 use libakaza::engine::base::HenkanEngine;
@@ -14,12 +15,19 @@ use serde_json::Value;
 
 use crate::jsonrpc::*;
 
+// macOS enforces a disk-write rate limit (~24.86 KB/s over 86400s). Writing on every
+// learn call (each keypress confirmation) caused akaza-server to be killed after ~20h of use.
+// Flush at most once per 5 minutes; always flush on shutdown.
+const FLUSH_INTERVAL: Duration = Duration::from_secs(300);
+
 pub struct Handler<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> {
     engine: BigramWordViterbiEngine<U, B, KD>,
     dict_path: String,
     model_dir: String,
     unigram_lm: MarisaSystemUnigramLM,
     bigram_lm: MarisaSystemBigramLM,
+    learn_dirty: bool,
+    last_flush: Option<Instant>,
 }
 
 impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD> {
@@ -36,6 +44,27 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
             model_dir,
             unigram_lm,
             bigram_lm,
+            learn_dirty: false,
+            last_flush: None,
+        }
+    }
+
+    pub fn flush_learn(&mut self) {
+        if !self.learn_dirty {
+            return;
+        }
+        match self.engine.user_data.lock() {
+            Ok(mut user_data) => {
+                if let Err(e) = user_data.write_user_files() {
+                    error!("flush_learn: failed to save user data: {}", e);
+                } else {
+                    self.learn_dirty = false;
+                    self.last_flush = Some(Instant::now());
+                }
+            }
+            Err(e) => {
+                error!("flush_learn: failed to lock user_data: {}", e);
+            }
         }
     }
 
@@ -186,26 +215,13 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
         self.engine.learn(&candidates);
         info!("Learned {} candidates", candidates.len());
 
-        // Persist learned data to disk
-        match self.engine.user_data.lock() {
-            Ok(mut user_data) => {
-                if let Err(e) = user_data.write_user_files() {
-                    error!("learn: failed to save user data: {}", e);
-                    return Response::error(
-                        request.id.clone(),
-                        INTERNAL_ERROR,
-                        format!("Failed to save learned data: {}", e),
-                    );
-                }
-            }
-            Err(e) => {
-                error!("learn: failed to lock user_data: {}", e);
-                return Response::error(
-                    request.id.clone(),
-                    INTERNAL_ERROR,
-                    "Failed to access user data".to_string(),
-                );
-            }
+        self.learn_dirty = true;
+        let should_flush = self
+            .last_flush
+            .map(|t| t.elapsed() >= FLUSH_INTERVAL)
+            .unwrap_or(true);
+        if should_flush {
+            self.flush_learn();
         }
 
         Response::success(request.id.clone(), Value::Bool(true))

--- a/akaza-server/src/main.rs
+++ b/akaza-server/src/main.rs
@@ -130,6 +130,7 @@ fn main() -> Result<()> {
         stdout.flush()?;
     }
 
+    handler.flush_learn();
     info!("akaza-server shutting down");
     Ok(())
 }


### PR DESCRIPTION
## Summary

- macOS は 1 プロセスのディスク書き込みを 86400 秒あたり ~2147 MB（~24.86 KB/s）に制限しており、超過するとプロセスを強制終了する
- `learn` リクエストのたびに unigram/bigram/skip-bigram の 3 ファイル（合計 ~1.5 MB）を AES 暗号化してフルで書き直していたため、長時間使用後に OS に kill されていた（実際に `akaza-server_2026-05-15-125526.diag` で確認済み）
- `handle_learn` をダーティフラグ方式に変更し、最大 5 分に 1 回のみフラッシュするよう修正（`FLUSH_INTERVAL = 300s`）
- シャットダウン時は必ず flush して学習データが消えないようにした
- CLAUDE.md に既知の問題とログ調査手順を追記

## Test plan

- [ ] `cargo build` が通ること（CI で確認）
- [ ] 変換確定後、5 分以内に akaza-server を終了してもユーザーデータが保存されること（shutdown flush の動作確認）