### PR TITLE
fix: スリープ復帰後に変換できなくなる問題を修正

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -23,7 +23,7 @@
     <true/>
 
     <key>InputMethodConnectionName</key>
-    <string>AkazaIME_1_Connection</string>
+    <string>com.github.tokuhirom.inputmethod.Japanese.Akaza_Connection</string>
     <key>InputMethodServerControllerClass</key>
     <string>AkazaInputController</string>
 

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -26,7 +26,7 @@ private func getConnectionName() -> String {
     if let name = Bundle.main.object(forInfoDictionaryKey: "InputMethodConnectionName") as? String {
         return name
     }
-    return "AkazaIME_1_Connection"
+    return (Bundle.main.bundleIdentifier ?? "com.github.tokuhirom.inputmethod.Japanese.Akaza") + "_Connection"
 }
 
 setupLogging()
@@ -60,4 +60,16 @@ if let skkJisyoLConfig = predefinedDownloadableDicts.first(where: { $0.id == "sk
 }
 
 NSLog("AkazaIME: IMKServer created successfully")
+
+// スリープ復帰後にサーバーを再起動してパイプ接続を回復する
+// macOS はスリープ中にパイプ接続を破棄することがあるため、ウェイク時に再起動が必要
+NSWorkspace.shared.notificationCenter.addObserver(
+    forName: NSWorkspace.didWakeNotification,
+    object: nil,
+    queue: .main
+) { _ in
+    NSLog("AkazaIME: wake from sleep — restarting akaza-server")
+    akazaServerProcess.restart()
+}
+
 NSApplication.shared.run()


### PR DESCRIPTION
## Summary

macOS スリープ後に AkazaIME が disabled 状態になり変換できなくなる問題を修正。

## 変更内容

### 1. `InputMethodConnectionName` をバンドルIDベースの値に変更 (`Info.plist`)

macOS 13.4 以降、スリープ復帰後にシステムが `InputMethodConnectionName` を無視して `$(PRODUCT_BUNDLE_IDENTIFIER)_Connection` に自動置換する仕様変更がある。`IMKServer` の初期化に使う接続名と macOS が期待する名前が不一致となり、IME が disabled になっていた。

- 旧: `AkazaIME_1_Connection`
- 新: `com.github.tokuhirom.inputmethod.Japanese.Akaza_Connection`

参考: https://gist.github.com/ShikiSuen/73b7a55526c9fadd2da2a16d94ec5b49

### 2. `NSWorkspace.didWakeNotification` でスリープ復帰時に akaza-server を再起動 (`main.swift`)

macOS スリープ中にパイプ接続が破棄されることがあり、復帰後に akaza-server との通信が不能になっていた。`NSWorkspace.didWakeNotification` を受信して `restart()` を呼ぶことで、新しいパイプ接続を確立する。

`restart()` 内で既に `onRestart` コールバック経由で `startReaderLoop()` が呼ばれるため、二重登録は不要。

## テスト

スリープ/ウェイクのテストは手動確認が必要。修正後はスリープ→復帰後も変換が継続して動作することを確認予定。