### PR TITLE
perf: 変換が200ms超えた場合にログを出力する

### DIFF
--- a/akaza-server/src/handler.rs
+++ b/akaza-server/src/handler.rs
@@ -142,7 +142,19 @@ impl<U: SystemUnigramLM, B: SystemBigramLM, KD: KanaKanjiDict> Handler<U, B, KD>
             }
         };
 
-        match self.engine.convert(&params.yomi, force_ranges.as_deref()) {
+        let char_count = params.yomi.chars().count();
+        let t0 = Instant::now();
+        let result = self.engine.convert(&params.yomi, force_ranges.as_deref());
+        let elapsed = t0.elapsed();
+        if elapsed.as_millis() > 200 {
+            error!(
+                "convert slow: {}ms, {} chars",
+                elapsed.as_millis(),
+                char_count
+            );
+        }
+
+        match result {
             Ok(clauses) => {
                 let result = Self::clauses_to_json(&clauses);
                 Response::success(request.id.clone(), result)


### PR DESCRIPTION
## Summary

- `convert` リクエストの処理時間を計測し、200ms を超えた場合にエラーログへ文字数を記録
- 元の文章はログに残さない（プライバシー配慮）

## 背景

スペースキー後に引っかかりを感じることがあり、実測したところ26文字の入力で約276msかかることを確認。目標は200ms以下。ログを入れることで問題の再現性・頻度を把握できるようにする。

ログの確認方法：
```sh
log stream --predicate 'process CONTAINS "Akaza"' --style compact
```

出力例：
```
convert slow: 276ms, 26 chars
```

## Test plan

- [ ] 短い入力（10文字以下）でログが出ないことを確認
- [ ] 長い入力（「じっさいにこのぐらいながいとおそいとかんじるんだよな」など）でログが出ることを確認