### PR TITLE
update akaza to v2026.530.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,31 @@ SERVER="$HOME/Library/Input Methods/Akaza.app/Contents/MacOS/akaza-server"
 
 ## バージョンアップ手順
 
-akaza ライブラリとモデルを新しいバージョン（例: `vYYYY.MMD.0`）に更新する場合、以下の 2 ファイルを修正する。
+akaza ライブラリとモデルを新しいバージョン（例: `vYYYY.MMD.0`）に更新する。
+
+### 重要: libakaza とモデルは同じ akaza リポジトリのタグを共有する
+
+akaza-default-model は **akaza 本体リポジトリ (akaza-im/akaza) にモノレポ化** された。
+モデルデータは `akaza-im/akaza` のリリースに `akaza-default-model.tar.gz` として添付され、
+`Makefile` の `download-model` ターゲットが `gh release download $(MODEL_VERSION) --repo akaza-im/akaza`
+で取得する（旧 `akaza-im/akaza-default-model` リポジトリからは取得しない）。
+
+したがって `libakaza` のタグと `MODEL_VERSION` は **常に同じ akaza のタグ** を指す。
+
+### 手順
+
+0. 更新前に main を最新化し、作業ブランチを切る
+   ```sh
+   git checkout main && git pull --ff-only origin main
+   git checkout -b update/akaza-vYYYY.MMD.0
+   ```
+
+   利用可能なタグとモデルアセットの存在を確認する。
+   ```sh
+   gh release list --repo akaza-im/akaza --limit 10
+   gh release view vYYYY.MMD.0 --repo akaza-im/akaza --json assets -q '.assets[].name'
+   # → akaza-default-model.tar.gz が含まれていることを確認
+   ```
 
 1. `akaza-server/Cargo.toml` の `libakaza` タグを更新
    ```toml
@@ -111,6 +135,11 @@ akaza ライブラリとモデルを新しいバージョン（例: `vYYYY.MMD.0
 3. `Cargo.lock` を更新
    ```sh
    cargo update -p libakaza
+   ```
+
+4. ビルドが通ることを確認する
+   ```sh
+   cargo build --release
    ```
 
 ## 誤変換の調査手順

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,8 +538,8 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libakaza"
-version = "2026.404.0"
-source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.404.0#842ea53164eef6fe647e3aa4844c3de58b60a295"
+version = "2026.530.0"
+source = "git+https://github.com/akaza-im/akaza.git?tag=v2026.530.0#2092e36cdb1d90643f2d1eaecbbf3908f22ed94b"
 dependencies = [
  "aes",
  "anyhow",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUTDIR = out/
 APP = $(OUTDIR)/Akaza.app
 INSTALL_DIR = $(HOME)/Library/Input Methods
-MODEL_VERSION = v2026.404.0
+MODEL_VERSION = v2026.530.0
 MODEL_DIR = $(OUTDIR)/model/$(MODEL_VERSION)
 MODEL_TARBALL = $(MODEL_DIR)/akaza-default-model.tar.gz
 

--- a/akaza-server/Cargo.toml
+++ b/akaza-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.404.0" }
+libakaza = { git = "https://github.com/akaza-im/akaza.git", tag = "v2026.530.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"

--- a/akaza-server/src/main.rs
+++ b/akaza-server/src/main.rs
@@ -88,6 +88,7 @@ fn main() -> Result<()> {
         dicts,
         dict_cache: true,
         reranking_weights: ReRankingWeights::default(),
+        convert_k: 10,
     };
 
     let engine = BigramWordViterbiEngineBuilder::new(config)


### PR DESCRIPTION
## 概要

akaza ライブラリとモデルを v2026.530.0 に更新する。

## 変更内容

- `akaza-server/Cargo.toml`: libakaza タグを `v2026.530.0` に更新
- `Makefile`: `MODEL_VERSION` を `v2026.530.0` に更新
- `Cargo.lock`: `cargo update -p libakaza` で更新
- `akaza-server/src/main.rs`: libakaza v2026.530.0 で `EngineConfig` に追加された `convert_k` フィールドへ対応（`convert_k: 10` で従来の既定値を維持）
- `CLAUDE.md`: バージョンアップ手順を更新（モノレポ化に伴いモデルは akaza-im/akaza のリリースから取得する旨を明記）

## 動作確認

- `cargo build --release` が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)