### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/akaza-im/mac-akaza/security/code-scanning/2](https://github.com/akaza-im/mac-akaza/security/code-scanning/2)

To fix this, add an explicit `permissions` block in `.github/workflows/rust.yml` at the workflow root (recommended here since there is only one job and all steps share the same needs). The least-privilege permission needed is:

- `contents: read`

This preserves current functionality (`actions/checkout` and local cargo commands) while preventing unintended write scopes on `GITHUB_TOKEN`.

Edit location:
- File: `.github/workflows/rust.yml`
- Insert `permissions:` after the `on:` trigger section (before `env:` is a clear location).

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
