### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/akaza-im/mac-akaza/security/code-scanning/1](https://github.com/akaza-im/mac-akaza/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/swift.yml` at the workflow root (recommended here since there is only one job). Use least privilege: `contents: read`, which is sufficient for `actions/checkout` and build-only behavior. This preserves existing functionality while ensuring token scope remains restricted even if repository/org defaults change.

Concretely:
- Edit `.github/workflows/swift.yml`.
- Insert, after the `on:` trigger section and before `jobs:`, the block:
  - `permissions:`
  - `  contents: read`
- No imports, methods, or extra definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
