### PR TITLE
fix: スリープ復帰時の akaza-server 二重起動を修正

### DIFF
--- a/Sources/AkazaIME/AkazaServerProcess.swift
+++ b/Sources/AkazaIME/AkazaServerProcess.swift
@@ -7,6 +7,7 @@ class AkazaServerProcess {
 
     private var restartCount = 0
     private var shouldRestart = true
+    private var pendingRestart: DispatchWorkItem?
 
     var onRestart: (() -> Void)?
     private var terminationObserver: NSObjectProtocol?
@@ -78,6 +79,11 @@ class AkazaServerProcess {
     }
 
     func start() {
+        if let existing = process, existing.isRunning {
+            NSLog("AkazaIME: akaza-server already running (pid=\(existing.processIdentifier)), skipping start")
+            return
+        }
+
         let serverPath = Bundle.main.bundlePath + "/Contents/MacOS/akaza-server"
         let modelPath = Bundle.main.bundlePath + "/Contents/Resources/model"
 
@@ -101,21 +107,9 @@ class AkazaServerProcess {
         proc.standardOutput = stdout
 
         proc.terminationHandler = { [weak self] terminatedProcess in
-            guard let self = self else { return }
             let status = terminatedProcess.terminationStatus
             NSLog("AkazaIME: akaza-server terminated with status \(status)")
-
-            guard self.shouldRestart else { return }
-
-            let delay = min(pow(2.0, Double(self.restartCount)), 15.0)
-            self.restartCount += 1
-            NSLog("AkazaIME: restarting akaza-server in \(delay)s (attempt \(self.restartCount))")
-
-            DispatchQueue.global().asyncAfter(deadline: .now() + delay) { [weak self] in
-                guard let self = self, self.shouldRestart else { return }
-                self.start()
-                self.onRestart?()
-            }
+            DispatchQueue.main.async { self?.handleTermination(of: terminatedProcess) }
         }
 
         do {
@@ -140,7 +134,28 @@ class AkazaServerProcess {
         }
     }
 
+    // メインキューで呼ばれること。self.process === terminatedProcess チェックで
+    // restart() が既に新プロセスを起動済みの場合の二重起動を防ぐ。
+    private func handleTermination(of terminatedProcess: Process) {
+        guard process === terminatedProcess, shouldRestart else { return }
+
+        let delay = min(pow(2.0, Double(restartCount)), 15.0)
+        restartCount += 1
+        NSLog("AkazaIME: restarting akaza-server in \(delay)s (attempt \(restartCount))")
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            self.pendingRestart = nil
+            self.start()
+            self.onRestart?()
+        }
+        pendingRestart = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
     func restart() {
+        pendingRestart?.cancel()
+        pendingRestart = nil
         shouldRestart = false
         process?.terminate()
         process?.waitUntilExit()
@@ -154,6 +169,8 @@ class AkazaServerProcess {
     }
 
     func stop() {
+        pendingRestart?.cancel()
+        pendingRestart = nil
         shouldRestart = false
         guard let proc = process, proc.isRunning else { return }
         NSLog("AkazaIME: stopping akaza-server")


### PR DESCRIPTION
## Summary

- スリープ復帰時に `terminationHandler` と `restart()` が競合し、`akaza-server` が2プロセス起動してしまうバグを修正
- ログ調査により実際の発生を確認: 2026-06-03 19:05 にpid=92846とpid=92870の2プロセスが起動した記録あり

## 原因

1. akaza-server がクラッシュ → `terminationHandler` がバックグラウンドスレッドで `shouldRestart=true` を確認し、1秒後の自動再起動をスケジュール
2. スリープ復帰 → `restart()` がメインスレッドで実行、`shouldRestart=false` にしてから新プロセスを起動し `shouldRestart=true` に戻す
3. 予約済みの1秒後再起動クロージャが `shouldRestart=true` を見て実行 → 2つ目の akaza-server が起動
4. 結果として AkazaIME は2つのプロセスに対してパイプを持った状態になり、変換不能になる

## 修正内容

- `pendingRestart: DispatchWorkItem?` を追加し、再起動をキャンセル可能にする
- `restart()` / `stop()` で `pendingRestart?.cancel()` を呼んで予約済み再起動をキャンセル
- `terminationHandler` をメインキューで処理し `self.process === terminatedProcess` チェックを追加（`restart()` が既に新プロセスを起動済みの場合に再起動しない）
- `start()` の先頭に二重起動ガードを追加（多重呼び出しへの防御）

## Test plan

- [ ] Mac をスリープ → 復帰を繰り返しても `akaza-server` が1プロセスのみ起動していることを `ps aux | grep akaza` で確認
- [ ] スリープ復帰後に日本語変換が正常に動作することを確認