### PR TITLE
feat: メニューから直接ユーザー辞書に単語を登録できるようにする

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Menu.swift
+++ b/Sources/AkazaIME/AkazaInputController+Menu.swift
@@ -1,0 +1,38 @@
+import Cocoa
+import InputMethodKit
+
+// MARK: - Menu
+
+extension AkazaInputController {
+    override func menu() -> NSMenu! {
+        let menu = NSMenu()
+        let registerItem = NSMenuItem(
+            title: "単語を登録...", action: #selector(registerWord(_:)), keyEquivalent: "")
+        registerItem.target = self
+        menu.addItem(registerItem)
+        menu.addItem(NSMenuItem.separator())
+        let settingsItem = NSMenuItem(
+            title: "設定...", action: #selector(openSettings(_:)), keyEquivalent: "")
+        settingsItem.target = self
+        menu.addItem(settingsItem)
+        return menu
+    }
+
+    @objc func registerWord(_ sender: Any?) {
+        let prefillYomi: String?
+        switch inputState {
+        case .composing:
+            let yomi = composedHiragana.isEmpty ? nil : composedHiragana
+            prefillYomi = yomi
+        default:
+            prefillYomi = nil
+        }
+        NSApp.activate(ignoringOtherApps: true)
+        UserDictionaryView.showAddEntryDialog(prefillYomi: prefillYomi)
+    }
+
+    @objc func openSettings(_ sender: Any?) {
+        PreferencesWindowController.shared.showWindow()
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}

--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -374,22 +374,9 @@ extension AkazaInputController {
     }
 }
 
-// MARK: - Menu
+// MARK: - Deactivate
 
 extension AkazaInputController {
-    override func menu() -> NSMenu! {
-        let menu = NSMenu()
-        let item = NSMenuItem(title: "設定...", action: #selector(openSettings(_:)), keyEquivalent: "")
-        item.target = self
-        menu.addItem(item)
-        return menu
-    }
-
-    @objc func openSettings(_ sender: Any?) {
-        PreferencesWindowController.shared.showWindow()
-        NSApp.activate(ignoringOtherApps: true)
-    }
-
     override func deactivateServer(_ sender: Any!) {
         cancelPendingSuggest()
         if let client = sender as? (any IMKTextInput), hasPreedit {

--- a/Sources/AkazaIME/UserDictionaryView.swift
+++ b/Sources/AkazaIME/UserDictionaryView.swift
@@ -67,6 +67,12 @@ class UserDictionaryView: NSView, NSTableViewDataSource, NSTableViewDelegate {
     }
 
     @objc private func addEntry(_ sender: Any?) {
+        UserDictionaryView.showAddEntryDialog(prefillYomi: nil) { [weak self] in
+            self?.loadEntries()
+        }
+    }
+
+    static func showAddEntryDialog(prefillYomi: String?, completion: (() -> Void)? = nil) {
         let alert = NSAlert()
         alert.messageText = "ユーザー辞書に追加"
         alert.addButton(withTitle: "追加")
@@ -79,6 +85,9 @@ class UserDictionaryView: NSView, NSTableViewDataSource, NSTableViewDelegate {
         container.addSubview(yomiLabel)
 
         let yomiField = NSTextField(frame: NSRect(x: 55, y: 34, width: 240, height: 22))
+        if let yomi = prefillYomi {
+            yomiField.stringValue = yomi
+        }
         container.addSubview(yomiField)
 
         let surfaceLabel = NSTextField(labelWithString: "表記:")
@@ -92,7 +101,7 @@ class UserDictionaryView: NSView, NSTableViewDataSource, NSTableViewDelegate {
         surfaceField.nextKeyView = yomiField
 
         alert.accessoryView = container
-        alert.window.initialFirstResponder = yomiField
+        alert.window.initialFirstResponder = prefillYomi != nil ? surfaceField : yomiField
 
         guard alert.runModal() == .alertFirstButtonReturn else { return }
 
@@ -101,7 +110,7 @@ class UserDictionaryView: NSView, NSTableViewDataSource, NSTableViewDelegate {
         guard !yomi.isEmpty, !surface.isEmpty else { return }
 
         _ = akazaClient.userDictAddSync(yomi: yomi, surface: surface)
-        loadEntries()
+        completion?()
     }
 
     @objc private func deleteEntry(_ sender: Any?) {


### PR DESCRIPTION
## Summary

- IME メニューに「単語を登録...」を追加し、設定画面を経由せずに単語登録ダイアログを直接開けるようにした
- preedit（composedHiragana）が入力中の場合、「読み」フィールドに自動入力される（表記フィールドにフォーカスが当たる）
- `UserDictionaryView.showAddEntryDialog(prefillYomi:completion:)` を static メソッドに切り出し、設定画面内の「追加...」ボタンも同じロジックを利用するようにリファクタリング
- メニュー関連コードを `AkazaInputController+Menu.swift` に分離（ファイル長制限対応）

## Test plan

- [ ] IME メニューから「単語を登録...」をクリックすると登録ダイアログが表示される
- [ ] preedit 入力中にメニューから開くと「読み」が自動入力され、「表記」フィールドにフォーカスが当たる
- [ ] preedit なしで開くと「読み」フィールドにフォーカスが当たる
- [ ] 読み・表記を入力して追加すると、設定画面のユーザー辞書タブに反映される
- [ ] 設定画面の「追加...」ボタンも引き続き正常に動作する