### PR TITLE
fix: ユーザー辞書ダイアログでコピー・ペーストが使えない問題を修正

### DIFF
--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -5,6 +5,33 @@ import InputMethodKit
 // akaza-server クラッシュ時にパイプ書き込みで SIGPIPE によりプロセスが終了するのを防ぐ
 signal(SIGPIPE, SIG_IGN)
 
+private func setupApplicationMenu() {
+    let mainMenu = NSMenu()
+
+    let appMenuItem = NSMenuItem()
+    mainMenu.addItem(appMenuItem)
+
+    let editMenuItem = NSMenuItem(title: "Edit", action: nil, keyEquivalent: "")
+    let editMenu = NSMenu(title: "Edit")
+    editMenu.addItem(
+        NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
+    editMenu.addItem(
+        NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "Z"))
+    editMenu.addItem(NSMenuItem.separator())
+    editMenu.addItem(
+        NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+    editMenu.addItem(
+        NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+    editMenu.addItem(
+        NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+    editMenu.addItem(
+        NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+    editMenuItem.submenu = editMenu
+    mainMenu.addItem(editMenuItem)
+
+    NSApp.mainMenu = mainMenu
+}
+
 private func setupLogging() {
     let logDir = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent("Library/Logs/AkazaIME")
@@ -30,6 +57,7 @@ private func getConnectionName() -> String {
 }
 
 setupLogging()
+setupApplicationMenu()
 NSLog("AkazaIME: starting")
 
 let connectionName = getConnectionName()


### PR DESCRIPTION
## 問題

ユーザー辞書の登録ダイアログ（NSAlert + accessoryView）のテキストフィールドで Cmd+C/V/X が効かなかった。

## 原因

IME アプリは `NSApp.mainMenu` を設定していなかったため、Edit メニュー（Cut/Copy/Paste 等）が存在せず、NSTextField のキーボードショートカットが機能しなかった。

## 修正

`main.swift` の起動時に `setupApplicationMenu()` を呼び出し、Cut/Copy/Paste/Undo/Redo/Select All を含む Edit メニューを `NSApp.mainMenu` に登録するようにした。

## Test plan

- [ ] ユーザー辞書ダイアログの「読み」「表記」フィールドで Cmd+V（ペースト）が動作する
- [ ] Cmd+C（コピー）、Cmd+X（カット）、Cmd+A（全選択）が動作する
- [ ] 通常の IME 入力動作に影響がないことを確認する