### PR TITLE
fix: setupApplicationMenu でのクラッシュを修正

### DIFF
--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -6,6 +6,8 @@ import InputMethodKit
 signal(SIGPIPE, SIG_IGN)
 
 private func setupApplicationMenu() {
+    let app = NSApplication.shared  // NSApp が nil のまま mainMenu を設定するとクラッシュするため先に初期化する
+
     let mainMenu = NSMenu()
 
     let appMenuItem = NSMenuItem()
@@ -29,7 +31,7 @@ private func setupApplicationMenu() {
     editMenuItem.submenu = editMenu
     mainMenu.addItem(editMenuItem)
 
-    NSApp.mainMenu = mainMenu
+    app.mainMenu = mainMenu
 }
 
 private func setupLogging() {


### PR DESCRIPTION
NSApp (NSApplication!) は NSApplication.shared を呼ぶ前は nil のため、 NSApp.mainMenu への代入で EXC_BREAKPOINT が発生していた。
setupApplicationMenu の先頭で NSApplication.shared を呼んで初期化してから mainMenu を設定するよう修正する。