### PR TITLE
feat: 変換中に0キーで別表記候補ダイアログを表示する

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+AlternativeSelection.swift
+++ b/Sources/AkazaIME/AkazaInputController+AlternativeSelection.swift
@@ -1,0 +1,150 @@
+import Cocoa
+import InputMethodKit
+
+struct AlternativeSelectionState {
+    let conversionSession: ConversionSession
+    let alternatives: [String]
+    var selectedIndex: Int = 0
+}
+
+// MARK: - Alternative selection (0 key during conversion)
+extension AkazaInputController {
+    func enterAlternativeSelection(client: any IMKTextInput) -> Bool {
+        guard case .converting(let session) = inputState else { return false }
+        guard let yomi = session.focusedCandidates.first?.yomi, !yomi.isEmpty else { return true }
+
+        let alternatives = buildAlternatives(yomi: yomi)
+        guard !alternatives.isEmpty else { return true }
+
+        alternativeSelectionState = AlternativeSelectionState(
+            conversionSession: session,
+            alternatives: alternatives
+        )
+        updateAlternativeMarkedText(client: client)
+        showAlternativeCandidateWindow(client: client)
+        return true
+    }
+
+    // Returns nil when not in alternative selection mode, Bool otherwise.
+    func handleAlternativeSelection(event: NSEvent, keyCode: UInt16, client: any IMKTextInput) -> Bool? {
+        guard alternativeSelectionState != nil else { return nil }
+
+        let isShiftPressed = event.modifierFlags.contains(.shift)
+
+        switch keyCode {
+        case 49: // Space
+            moveAlternativeSelection(by: isShiftPressed ? -1 : 1, client: client)
+            return true
+        case 125: // Down
+            moveAlternativeSelection(by: 1, client: client)
+            return true
+        case 126: // Up
+            moveAlternativeSelection(by: -1, client: client)
+            return true
+        case 36: // Enter
+            commitSelectedAlternative(client: client)
+            return true
+        case 53, 29: // Escape or 0 — cancel
+            cancelAlternativeSelection(client: client)
+            return true
+        default:
+            if let chars = event.characters, let char = chars.first,
+               let number = Int(String(char)), (1...9).contains(number) {
+                let index = number - 1
+                if index < alternativeSelectionState!.alternatives.count {
+                    selectAlternativeAt(index, client: client)
+                }
+                return true
+            }
+            cancelAlternativeSelection(client: client)
+            return handleConvertingState(event: event, keyCode: keyCode, client: client)
+        }
+    }
+
+    private func moveAlternativeSelection(by offset: Int, client: any IMKTextInput) {
+        guard var state = alternativeSelectionState else { return }
+        let count = state.alternatives.count
+        state.selectedIndex = (state.selectedIndex + offset + count) % count
+        alternativeSelectionState = state
+        updateAlternativeMarkedText(client: client)
+        showAlternativeCandidateWindow(client: client)
+    }
+
+    private func selectAlternativeAt(_ index: Int, client: any IMKTextInput) {
+        guard var state = alternativeSelectionState, index < state.alternatives.count else { return }
+        state.selectedIndex = index
+        alternativeSelectionState = state
+        commitSelectedAlternative(client: client)
+    }
+
+    func commitSelectedAlternative(client: any IMKTextInput) {
+        guard let state = alternativeSelectionState else { return }
+        let alternative = state.alternatives[state.selectedIndex]
+        let session = state.conversionSession
+
+        let text = session.clauses.enumerated().compactMap { idx, candidates -> String? in
+            guard !candidates.isEmpty else { return nil }
+            return idx == session.focusedClauseIndex
+                ? alternative
+                : candidates[session.selectedCandidateIndices[idx]].surface
+        }.joined()
+
+        client.insertText(text, replacementRange: NSRange(location: NSNotFound, length: 0))
+        alternativeSelectionState = nil
+        resetToComposing()
+    }
+
+    func cancelAlternativeSelection(client: any IMKTextInput) {
+        guard let state = alternativeSelectionState else { return }
+        alternativeSelectionState = nil
+        inputState = .converting(state.conversionSession)
+        updateConvertingMarkedText(client: client)
+        updateConversionCandidateWindow(client: client, trigger: .conversionNavigation)
+    }
+
+    func updateAlternativeMarkedText(client: any IMKTextInput) {
+        guard let state = alternativeSelectionState else { return }
+        let session = state.conversionSession
+        let alternative = state.alternatives[state.selectedIndex]
+
+        let attributed = NSMutableAttributedString()
+        for (clauseIndex, candidates) in session.clauses.enumerated() {
+            guard !candidates.isEmpty else { continue }
+            let isFocused = clauseIndex == session.focusedClauseIndex
+            let surface = isFocused ? alternative : candidates[session.selectedCandidateIndices[clauseIndex]].surface
+            let underlineStyle: NSUnderlineStyle = isFocused ? .thick : .single
+            let attrs: [NSAttributedString.Key: Any] = [
+                .underlineStyle: underlineStyle.rawValue,
+                .markedClauseSegment: clauseIndex
+            ]
+            attributed.append(NSAttributedString(string: surface, attributes: attrs))
+        }
+
+        let fullLength = attributed.length
+        client.setMarkedText(
+            attributed,
+            selectionRange: NSRange(location: fullLength, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+    }
+
+    func showAlternativeCandidateWindow(client: any IMKTextInput) {
+        guard let state = alternativeSelectionState else { return }
+        var lineHeightRect = NSRect.zero
+        client.attributes(forCharacterIndex: 0, lineHeightRectangle: &lineHeightRect)
+        Self.candidateWindow.showAlternatives(
+            state.alternatives,
+            selectedIndex: state.selectedIndex,
+            cursorRect: lineHeightRect
+        )
+    }
+
+    private func buildAlternatives(yomi: String) -> [String] {
+        var result: [String] = [yomi]
+        let katakana = yomi.toKatakana()
+        if katakana != yomi { result.append(katakana) }
+        let halfKatakana = yomi.toHalfWidthKatakana()
+        if halfKatakana != katakana { result.append(halfKatakana) }
+        return result
+    }
+}

--- a/Sources/AkazaIME/AkazaInputController+Converting.swift
+++ b/Sources/AkazaIME/AkazaInputController+Converting.swift
@@ -18,6 +18,8 @@ extension AkazaInputController {
             return handlePreviousCandidateInConverting(client: client)
         case 123, 124: // Left, Right arrow
             return handleArrowKeyInConverting(keyCode: keyCode, isShiftPressed: isShiftPressed, client: client)
+        case 29: // 0 — open alternative notation dialog
+            return enterAlternativeSelection(client: client)
         case 36: // Enter
             return handleEnterInConverting(client: client)
         case 53: // Escape

--- a/Sources/AkazaIME/AkazaInputController.swift
+++ b/Sources/AkazaIME/AkazaInputController.swift
@@ -20,6 +20,7 @@ class AkazaInputController: IMKInputController {
     static let candidateWindow = CandidateWindowController()
     var inputHistory: [ComposingSnapshot] = []
     var functionKeyState: FunctionKeyState?
+    var alternativeSelectionState: AlternativeSelectionState?
 
     override init!(server: IMKServer!, delegate: Any!, client inputClient: Any!) {
         super.init(server: server, delegate: delegate, client: inputClient)
@@ -56,6 +57,7 @@ class AkazaInputController: IMKInputController {
 
     var hasPreedit: Bool {
         if functionKeyState != nil { return true }
+        if alternativeSelectionState != nil { return true }
         switch inputState {
         case .composing:
             return !composedHiragana.isEmpty || !romajiConverter.pendingRomaji.isEmpty
@@ -297,6 +299,9 @@ extension AkazaInputController {
             if hasPreedit { commitCurrentState(client: client) }
             return false
         }
+        if let result = handleAlternativeSelection(event: event, keyCode: keyCode, client: client) {
+            return result
+        }
         switch inputState {
         case .composing:
             return handleComposingState(event: event, keyCode: keyCode, client: client)
@@ -312,6 +317,10 @@ extension AkazaInputController {
 
 extension AkazaInputController {
     func commitCurrentState(client: any IMKTextInput) {
+        if alternativeSelectionState != nil {
+            commitSelectedAlternative(client: client)
+            return
+        }
         switch inputState {
         case .composing:
             commitComposingText(client: client)
@@ -355,6 +364,7 @@ extension AkazaInputController {
     func resetToComposing() {
         cancelPendingSuggest()
         functionKeyState = nil
+        alternativeSelectionState = nil
         inputState = .composing
         composedHiragana = ""
         isDirectInputMode = false

--- a/Sources/AkazaIME/CandidateWindowController.swift
+++ b/Sources/AkazaIME/CandidateWindowController.swift
@@ -150,6 +150,10 @@ class CandidateWindowController {
         showSurfaces(suggestions, selectedIndex: selectedIndex, cursorRect: cursorRect, stablePosition: true)
     }
 
+    func showAlternatives(_ alternatives: [String], selectedIndex: Int, cursorRect: NSRect) {
+        showSurfaces(alternatives, selectedIndex: selectedIndex, cursorRect: cursorRect, stablePosition: false)
+    }
+
     func hide() {
         panel.orderOut(nil)
     }


### PR DESCRIPTION
## Summary

- 変換中（Converting状態）に `0` キーを押すと、フォーカス中の文節の別表記候補ダイアログを開くようにした
- 表示候補: ひらがな／全角カタカナ／半角カタカナ（読みから自動生成、重複除外）
- preedit もリアルタイムでプレビューが切り替わる

## 背景

変換候補リストにはカタカナ等の別表記候補がすでに含まれているが、通常候補の下位に埋もれているため辿り着くのが面倒だった。ATOKの「0キーで別表記候補ダイアログを出す」動作を参考に、すぐにアクセスできるUIを追加した。

## キー操作

| キー | 動作 |
|---|---|
| `0` | ダイアログを開く（再度押すと閉じる） |
| `Space` / `↓` | 次の候補へ |
| `Shift+Space` / `↑` | 前の候補へ |
| `1`〜`9` | 番号で直接選択・確定 |
| `Enter` | 選択中の候補で確定 |
| `Escape` | キャンセルして変換状態に戻る |

## Test plan

- [ ] 変換中に `0` キーを押してダイアログが開くことを確認
- [ ] ひらがな／カタカナ／半角カタカナの候補が表示されることを確認
- [ ] Space・数字キー・Enter で選択・確定できることを確認
- [ ] Escape でキャンセルして変換状態に戻れることを確認
- [ ] 複数文節の変換中、他の文節は変わらずフォーカス中の文節だけ別表記になることを確認
- [ ] `deactivateServer` 時（フォーカス移動等）に正しくコミットされることを確認