### PR TITLE
fix: akaza-server のデフォルトログレベルを warn に変更

### DIFF
--- a/akaza-server/src/main.rs
+++ b/akaza-server/src/main.rs
@@ -16,7 +16,7 @@ use libakaza::user_side_data::user_data::UserData;
 use log::info;
 
 fn main() -> Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
         .target(env_logger::Target::Stderr)
         .init();
 


### PR DESCRIPTION
## Summary

- `akaza-server/src/main.rs` のデフォルトログレベルを `info` → `warn` に変更
- `libakaza::graph::lattice_graph` の `Use user's node score: WordNode {...}` メッセージが変換ごとに数十行出力されており、ログファイルが 2.2 GB に膨張していた
- macOS のディスク書き込み制限（約 2147 MB/86400s/プロセス）に抵触して akaza-server の stdout 書き込みがスロットリングされ、変換が応答しなくなっていた

## 詳細

`RUST_LOG=info` を環境変数に設定することで従来の詳細ログは引き続き有効化できる。

## Test plan

- [ ] `cargo build --release` が通ること
- [ ] インストール後に通常使用でログファイルが肥大化しないこと（`~/Library/Logs/AkazaIME/akaza.log` の増加速度が大幅に減少）
- [ ] 変換が正常に動作すること