### PR TITLE
fix: スリープ復帰後に Akaza が disabled になる wedge を自動回復

### DIFF
--- a/Sources/AkazaIME/InputSourceEnabler.swift
+++ b/Sources/AkazaIME/InputSourceEnabler.swift
@@ -1,0 +1,71 @@
+import Carbon
+import Foundation
+
+// スリープ復帰後に Akaza の入力ソースが OS によって無効化（メニューバーで disabled）
+// される "サイレント wedge" への対策。
+//
+// 観測された症状: wake 後に Akaza が AppleEnabledInputSources から外され、選択不能になる。
+// プロセスは生存しているため、本プロセス内から TISEnableInputSource で再有効化できる。
+//
+// 注意:
+//   - 再有効化対象は「入力メソッド本体」と「.Japanese モード」に限定する。
+//     `.Roman` モードは正常時から無効（ユーザーが使っていない）なので触らない。
+//   - 操作前に全 Akaza 系入力ソースの有効状態をログに残す。次回再発時に
+//     「どのエントリが無効化されたか」を確定し、因果の裏取りに使う。
+enum InputSourceEnabler {
+    /// 入力メソッド本体の ID。バンドル ID と一致する。
+    private static var inputMethodID: String {
+        Bundle.main.bundleIdentifier ?? "com.github.tokuhirom.inputmethod.Japanese.Akaza"
+    }
+
+    /// 再有効化対象の入力ソース ID 群（本体 + 主要モード）。`.Roman` は含めない。
+    private static var targetIDs: [String] {
+        let base = inputMethodID
+        return [base, base + ".Japanese"]
+    }
+
+    /// 無効化されていれば再有効化する。再有効化を 1 件以上行ったら true。
+    /// 冪等: 既に有効な入力ソースには何もしない。
+    @discardableResult
+    static func enableIfDisabled() -> Bool {
+        guard let listRef = TISCreateInputSourceList(nil, true)?.takeRetainedValue() else {
+            NSLog("AkazaIME[diag]: TISCreateInputSourceList failed")
+            return false
+        }
+        let count = CFArrayGetCount(listRef)
+        let targets = Set(targetIDs)
+        var enabledAny = false
+        for index in 0..<count {
+            let src = unsafeBitCast(CFArrayGetValueAtIndex(listRef, index), to: TISInputSource.self)
+            guard let id = stringProperty(src, kTISPropertyInputSourceID), id.contains("Akaza") else { continue }
+            let isEnabled = boolProperty(src, kTISPropertyInputSourceIsEnabled) ?? false
+            let canEnable = boolProperty(src, kTISPropertyInputSourceIsEnableCapable) ?? false
+            // 検証用: 全 Akaza 系ソースの状態を記録する（再発時にどれが落ちたか確定するため）。
+            NSLog("AkazaIME[diag]: TIS source id=\(id) enabled=\(isEnabled) enableCapable=\(canEnable)")
+            guard targets.contains(id), !isEnabled, canEnable else { continue }
+            let status = TISEnableInputSource(src)
+            NSLog("AkazaIME[diag]: re-enabled disabled input source id=\(id) status=\(status)")
+            if status == noErr { enabledAny = true }
+        }
+        return enabledAny
+    }
+
+    /// wake 直後は OS による無効化のタイミングが読めないため、複数の遅延で再試行する。
+    static func scheduleReEnable(delays: [Double] = [0, 2, 10, 30]) {
+        for delay in delays {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                _ = enableIfDisabled()
+            }
+        }
+    }
+
+    private static func boolProperty(_ src: TISInputSource, _ key: CFString) -> Bool? {
+        guard let ptr = TISGetInputSourceProperty(src, key) else { return nil }
+        return CFBooleanGetValue(Unmanaged<CFBoolean>.fromOpaque(ptr).takeUnretainedValue())
+    }
+
+    private static func stringProperty(_ src: TISInputSource, _ key: CFString) -> String? {
+        guard let ptr = TISGetInputSourceProperty(src, key) else { return nil }
+        return (Unmanaged<CFString>.fromOpaque(ptr).takeUnretainedValue() as String)
+    }
+}

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -100,6 +100,9 @@ NSWorkspace.shared.notificationCenter.addObserver(
 ) { _ in
     NSLog("AkazaIME: wake from sleep — restarting akaza-server")
     akazaServerProcess.restart()
+    // 経路A 対策: wake 後に OS が Akaza を無効化（メニューバーで disabled）する wedge への対処。
+    // 無効化のタイミングが読めないため複数の遅延で再有効化を試みる。
+    InputSourceEnabler.scheduleReEnable()
 }
 
 NSApplication.shared.run()


### PR DESCRIPTION
## 背景

mac-akaza で最も深刻かつ再発を繰り返すバグ: macOS スリープ復帰後（特に土日を挟む長時間スリープ）に Akaza がメニューバーで **disabled** になり選択不能になる。プロセスは生存しており `killall` でも回復しない＝壊れているのは OS 側（IMKit/HIToolbox のキールーティング）。診断ログ（経路A調査ビルド）で、wake 後に Akaza が `AppleEnabledInputSources` から外され、OS→IME の keyDown 配送（往路）が断たれることを確認済み。

## 修正内容

wake 時に `TISEnableInputSource` で Akaza の入力ソースを自動再有効化する。

- 再有効化対象は **入力メソッド本体** と **`.Japanese` モード** のみ。`.Roman` は正常時から無効（未使用）なので触らない。
- 冪等: 既に有効なソースには何もしない。
- OS による無効化のタイミングが読めないため `didWakeNotification` から `[0, 2, 10, 30]` 秒で再試行する。
- 再有効化の前に全 Akaza 系 TIS ソースの `enabled`/`enableCapable` を `[diag]` ログに記録する。次回再発時に **どのエントリが実際に無効化されたか** が確定でき、根本原因（署名/notarization 仮説）の裏取りにも使える。

## 位置づけ・既知の限界

- 観測済みの症状（disabled 化）を直接叩く対症療法。無効化の根本原因（ad-hoc 署名 / 未 notarize による wake 時の再検証、という仮説）はまだ未確定。
- wedge 中の無効化エントリのスナップショットは未捕捉のため「親 + `.Japanese` が落ちる」は推定。今回ログ捕捉を仕込んだので、推定が外れていてもログから対象を補正できる。

## 動作確認

- `swift build -c release` 通過
- swiftlint クリーン
- TIS 列挙 PoC で現状の入力ソース構成（本体 / `.Japanese`(enabled) / `.Roman`(disabled)）を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)