### PR TITLE
[codex] Document IMKit review and remove wake server recreation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ bundle: download-model
 	cp $(MODEL_DIR)/akaza-default-model/*.model $(APP)/Contents/Resources/model/
 	cp $(MODEL_DIR)/akaza-default-model/*.model.scores $(APP)/Contents/Resources/model/
 	cp $(MODEL_DIR)/akaza-default-model/SKK-JISYO.* $(APP)/Contents/Resources/model/
+	codesign --force --deep --sign - $(APP)
 
 install: build bundle
 	rm -rf "$(INSTALL_DIR)/Akaza.app"

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -65,11 +65,12 @@ NSLog("AkazaIME: starting")
 let connectionName = getConnectionName()
 NSLog("AkazaIME: connection name = \(connectionName)")
 
-guard let server = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier) else {
+// wake 時に作り直せるよう var で保持する（経路A: 接続腐敗の予防実験）
+var imkServer = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier)
+guard imkServer != nil else {
     NSLog("AkazaIME: failed to create IMKServer")
     exit(1)
 }
-_ = server // IMKServer を保持
 
 let akazaServerProcess = AkazaServerProcess()
 let akazaClient = JSONRPCClient(serverProcess: akazaServerProcess)
@@ -100,6 +101,33 @@ NSWorkspace.shared.notificationCenter.addObserver(
 ) { _ in
     NSLog("AkazaIME: wake from sleep — restarting akaza-server")
     akazaServerProcess.restart()
+
+    // 経路A 予防実験: wake 後に OS↔AkazaIME の IMKit 接続が腐って keyDown(往路)が
+    // 届かなくなる wedge を、接続が壊れる前に IMKServer を能動的に張り直して防ぐ。
+    // 効果は未検証なので [diag] で観測する。最悪 IMKServer が作れなくても killall /
+    // 自動再起動で回復するため、reboot を要する現状の wedge より悪化はしない。
+    //
+    // 手順を分けるのが重要: まず旧 IMKServer を解放し、runloop を1サイクル回して
+    // Mach ポート名の解放(非同期)を待ってから、同名で作り直す。同期に nil→再 init
+    // すると名前衝突で失敗しやすい。
+    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        NSLog("AkazaIME[diag]: wake — releasing IMKServer (name=\(connectionName))")
+        imkServer = nil // 旧接続を畳む（ARC で dealloc → Mach ポート名を解放）
+
+        func recreate(attempt: Int) {
+            imkServer = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier)
+            if imkServer != nil {
+                NSLog("AkazaIME[diag]: IMKServer recreated on wake (attempt=\(attempt))")
+            } else if attempt < 5 {
+                NSLog("AkazaIME[diag]: IMKServer recreate failed (attempt=\(attempt)) — retrying")
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) { recreate(attempt: attempt + 1) }
+            } else {
+                NSLog("AkazaIME[diag]: WARNING IMKServer recreate gave up after \(attempt) attempts — killall to recover")
+            }
+        }
+        // 解放を runloop に消化させてから再生成する
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { recreate(attempt: 1) }
+    }
 }
 
 NSApplication.shared.run()

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -65,8 +65,7 @@ NSLog("AkazaIME: starting")
 let connectionName = getConnectionName()
 NSLog("AkazaIME: connection name = \(connectionName)")
 
-// wake 時に作り直せるよう var で保持する（経路A: 接続腐敗の予防実験）
-var imkServer = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier)
+let imkServer = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier)
 guard imkServer != nil else {
     NSLog("AkazaIME: failed to create IMKServer")
     exit(1)
@@ -102,32 +101,8 @@ NSWorkspace.shared.notificationCenter.addObserver(
     NSLog("AkazaIME: wake from sleep — restarting akaza-server")
     akazaServerProcess.restart()
 
-    // 経路A 予防実験: wake 後に OS↔AkazaIME の IMKit 接続が腐って keyDown(往路)が
-    // 届かなくなる wedge を、接続が壊れる前に IMKServer を能動的に張り直して防ぐ。
-    // 効果は未検証なので [diag] で観測する。最悪 IMKServer が作れなくても killall /
-    // 自動再起動で回復するため、reboot を要する現状の wedge より悪化はしない。
-    //
-    // 手順を分けるのが重要: まず旧 IMKServer を解放し、runloop を1サイクル回して
-    // Mach ポート名の解放(非同期)を待ってから、同名で作り直す。同期に nil→再 init
-    // すると名前衝突で失敗しやすい。
-    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-        NSLog("AkazaIME[diag]: wake — releasing IMKServer (name=\(connectionName))")
-        imkServer = nil // 旧接続を畳む（ARC で dealloc → Mach ポート名を解放）
-
-        func recreate(attempt: Int) {
-            imkServer = IMKServer(name: connectionName, bundleIdentifier: Bundle.main.bundleIdentifier)
-            if imkServer != nil {
-                NSLog("AkazaIME[diag]: IMKServer recreated on wake (attempt=\(attempt))")
-            } else if attempt < 5 {
-                NSLog("AkazaIME[diag]: IMKServer recreate failed (attempt=\(attempt)) — retrying")
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1) { recreate(attempt: attempt + 1) }
-            } else {
-                NSLog("AkazaIME[diag]: WARNING IMKServer recreate gave up after \(attempt) attempts — killall to recover")
-            }
-        }
-        // 解放を runloop に消化させてから再生成する
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { recreate(attempt: 1) }
-    }
+    // IMKServer の wake 時再生成は 2026-06-26 に main thread を詰まらせる疑いが
+    // 強くなったため行わない。経路A の回復はバンドル再登録側で検証する。
 }
 
 NSApplication.shared.run()

--- a/docs/imkit-documentation-review.md
+++ b/docs/imkit-documentation-review.md
@@ -1,0 +1,167 @@
+# InputMethodKit documentation review
+
+Date: 2026-06-26
+
+This note summarizes a review of Apple's InputMethodKit documentation against the current AkazaIME implementation. The review covered the InputMethodKit top-level documentation and the linked classes, protocols, constants, data types, and method pages exposed from that page. The same contracts were cross-checked against the Xcode SDK headers because the Apple Developer Documentation pages are DocC/JavaScript backed.
+
+Primary sources:
+
+- https://developer.apple.com/documentation/inputmethodkit
+- https://developer.apple.com/documentation/inputmethodkit/imkserver
+- https://developer.apple.com/documentation/inputmethodkit/imkinputcontroller
+- https://developer.apple.com/documentation/inputmethodkit/imkcandidates
+- https://developer.apple.com/documentation/inputmethodkit/imkstatesetting
+- https://developer.apple.com/documentation/inputmethodkit/imkserverinput
+- Xcode SDK headers:
+  - `InputMethodKit.framework/Headers/IMKServer.h`
+  - `InputMethodKit.framework/Headers/IMKInputController.h`
+  - `HIToolbox.framework/Headers/IMKInputSession.h`
+  - `HIToolbox.framework/Headers/TextInputSources.h`
+
+## Summary
+
+The current one-server startup model is consistent with IMKit. `IMKServer` should be created by the input method's main function and kept as the server for client sessions. The previous wake-time experiment that released and recreated `IMKServer` inside the running process was not consistent with the documented model and likely contributed to the 2026-06-26 hang.
+
+The remaining issues are mostly around composition lifecycle coverage and asynchronous callbacks. The highest-priority implementation gap is `commitComposition(_:)`, which IMKit can call independently of `deactivateServer(_:)`.
+
+## Documentation contracts relevant to AkazaIME
+
+### `IMKServer`
+
+`IMKServer` represents the input method to the rest of the system and manages client sessions. The SDK header states that an input method should create exactly one `IMKServer`. It creates a connection and creates an `IMKInputController` for each client input session.
+
+Implication for AkazaIME:
+
+- Creating a single server in `main.swift` is correct.
+- Releasing and recreating `IMKServer` on wake is risky and should not be used as a recovery strategy.
+- Recovery from OS-side IMKit registration corruption should be handled outside the live `IMKServer` object, such as through bundle registration/install flows or user-session recovery.
+
+Current state:
+
+- `main.swift` now keeps a single `let imkServer`.
+- Wake handling only restarts `akaza-server`; it no longer touches `IMKServer`.
+
+### `IMKServerInput`
+
+IMKit supports three input styles:
+
+1. key binding via `inputText(_:client:)` and `didCommand(by:client:)`
+2. unpacked key data via `inputText(_:key:modifiers:client:)`
+3. direct `NSEvent` delivery via `handle(_:client:)`
+
+AkazaIME uses the third style by overriding `handle(_:client:)`, which is appropriate for its key-code-sensitive Japanese IME behavior.
+
+Important return-value contract:
+
+- Return `true` only when the event was handled.
+- Return `false` when the client application should receive the event.
+
+Current state:
+
+- This is broadly respected for Tab, function keys with no preedit, and command/control/option cases.
+- The code intentionally consumes some keys to prevent unwanted text insertion while composing/converting.
+
+### `commitComposition(_:)`
+
+The `IMKServerInput` informal protocol includes `commitComposition(_:)`. IMKit calls it when the client wants the composition session to end immediately. The documented response is to call the client's `insertText` and clean up per-session buffers.
+
+`recognizedEvents(_:)` defaults to key-down events. When an input method only recognizes key-down events, IMKit provides default mouse handling. If there is an active composition and the user clicks outside it, IMKit sends `commitComposition(_:)`.
+
+Issue:
+
+- AkazaIME commits on `deactivateServer(_:)`, but it does not currently implement `commitComposition(_:)`.
+- This leaves an IMKit-standard composition-ending path uncovered.
+
+Recommended fix:
+
+- Implement `commitComposition(_:)` on `AkazaInputController`.
+- If `sender` conforms to `IMKTextInput` and `hasPreedit` is true, call `commitCurrentState(client:)`.
+- Always reset composition state and hide candidate UI afterward.
+
+### `deactivateServer(_:)`
+
+`deactivateServer(_:)` is the activation lifecycle hook. It is not the only composition-ending path.
+
+Current state:
+
+- AkazaIME cancels pending suggestions, commits current state when possible, resets local state, and calls `super.deactivateServer(sender)`.
+- This is reasonable, but should not be treated as a substitute for `commitComposition(_:)`.
+
+### `IMKTextInput`
+
+`insertText(_:replacementRange:)` and `setMarkedText(_:selectionRange:replacementRange:)` use `NSNotFound` replacement ranges to mean "current insertion point." Selection ranges are relative to the marked string.
+
+Current state:
+
+- AkazaIME's `diagInsertText` and `diagSetMarkedText` use `NSRange(location: NSNotFound, length: 0)`, which matches the documented current-insertion-point behavior.
+- Selection ranges for marked text are relative to the marked string, which matches the documentation.
+
+### Async conversion callbacks
+
+IMKit creates an `IMKInputController` per client input session, and that controller has a client object. AkazaIME's conversion requests return asynchronously and capture the `client` passed to the key event handler.
+
+Issue:
+
+- If the controller is deactivated, the composition is reset, or a stale conversion result arrives after a client/session transition, the callback can still attempt to update marked text or candidate UI using the captured client.
+- Existing state guards catch many stale responses, but they do not explicitly invalidate callbacks on activation/deactivation generation changes.
+
+Recommended fix:
+
+- Add a generation token on `AkazaInputController`.
+- Increment it on `activateServer(_:)`, `deactivateServer(_:)`, and `commitComposition(_:)`.
+- Capture the generation when starting async conversion/suggestion work.
+- Drop completion callbacks when the generation no longer matches.
+
+### Candidate UI
+
+`IMKCandidates` is optional. Custom candidate windows are allowed in practice, but the IMKit docs and headers provide facilities that matter for correct placement and event behavior.
+
+Issue:
+
+- AkazaIME uses a custom `NSPanel`, not `IMKCandidates`.
+- The panel level is fixed to `.popUpMenu`.
+- IMK's client protocol exposes `windowLevel()` specifically so custom candidate windows can align with the client window level.
+- Candidate positioning uses `NSScreen.main`, which can be wrong for multi-display, full-screen, or different-Space client windows.
+
+Recommended fix:
+
+- When showing the custom candidate window, use `client.windowLevel() + 1` where available instead of a fixed level.
+- Determine the screen from the cursor rect rather than `NSScreen.main`.
+- Keep the zero-rect fallback, but log it as diagnostic information while this issue is being investigated.
+
+### Info.plist and TIS registration
+
+`TextInputSources.h` says application-based input methods live in `~/Library/Input Methods/` or `/Library/Input Methods/`. For input methods, top-level `TISInputSourceID` is typically the same as the bundle ID; if omitted, the bundle ID is used. Input modes are declared under `ComponentInputModeDict` with `tsInputModeListKey`, and mode `TISInputSourceID` values should begin with the parent input method's ID or bundle ID.
+
+Current state:
+
+- `ComponentInputModeDict` and `tsInputModeListKey` are present.
+- Japanese and Roman mode IDs begin with `com.github.tokuhirom.inputmethod.Japanese.Akaza`.
+- The top-level `TISInputSourceID` is omitted, relying on the default bundle ID behavior.
+
+Recommended hardening:
+
+- Add top-level `TISInputSourceID` with `com.github.tokuhirom.inputmethod.Japanese.Akaza` to make registration state less implicit.
+- Continue signing the `.app` bundle during `make bundle`; otherwise the signature identifier can diverge from `CFBundleIdentifier`, confusing LaunchServices/TIS.
+
+### Preferences menu
+
+IMKit provides a default `showPreferences(_:)` path if a menu item uses that selector and a preferences nib/controller is configured. AkazaIME uses a custom SwiftUI/AppKit preferences window instead.
+
+Current state:
+
+- This is acceptable, but it is outside the standard `showPreferences(_:)` path.
+- No immediate correctness issue was found.
+
+## Prioritized action list
+
+1. Implement `commitComposition(_:)`.
+2. Add async callback generation invalidation around conversion and suggestion completions.
+3. Add top-level `TISInputSourceID` to `Info.plist`.
+4. Use the client window level and cursor screen for the custom candidate panel.
+5. Keep `IMKServer` lifetime fixed for the process lifetime; do not recreate it on wake.
+6. Keep app-bundle signing in the build/install flow.
+
+## Notes from 2026-06-26 incident
+
+The wake-time `IMKServer` recreation experiment logged `wake — releasing IMKServer` and then failed to log either success or retry failure. Since the next statement after recreation would have logged the result, the likely failure mode is that `IMKServer(name:bundleIdentifier:)` did not return on the main thread. This is consistent with the documentation warning implied by the `IMKServer` lifetime model: the server is intended to be created once, not treated as a reconnectable session object.

--- a/docs/sleep-wake-investigation.md
+++ b/docs/sleep-wake-investigation.md
@@ -208,6 +208,28 @@ wake 通知時に `akaza-server` 再起動に加えて **`IMKServer` 自体を�
 ### 10-5. 補足: 今回の wedge 直前にスリープは無かった
 pmset ログ上、wedge が顕在化した時刻の直前にスリープ/ロックは無く（Caffeine 稼働中）、当日朝の wake 由来の潜在破損が後から顕在化した可能性がある。⇒ **wake トリガだけの対策では取りこぼす恐れ**。署名/notarization 仮説は最有力だが未確定のまま（GUI 再追加時の trustd 署名検証バーストは状況証拠どまり）。
 
+### 10-6. 2026-06-26: `IMKServer` wake 時再生成は main thread を詰まらせる疑いが強い
+07:40 の wake 後ログで以下を確認した:
+
+- `AkazaIME: wake from sleep — restarting akaza-server`
+- `AkazaIME[diag]: wake — releasing IMKServer (...)`
+- その後に期待した `IMKServer recreated on wake` / `recreate failed` が出ない
+- 以後、別プロセスとして AkazaIME が起動し直されるまで通常の `handle` ログが出ない
+
+コード上は `imkServer = IMKServer(...)` の直後に成功/失敗ログを出すため、ログが途切れた位置から **`IMKServer` initializer 自体が main thread 上で戻っていない**可能性が高い。したがって wake 時に同一プロセス内で `IMKServer` を破棄/再生成する予防実験は撤去した。経路A の回復は、既に効果を確認した `make install` によるバンドル再登録、またはそれに近い OS 側再登録手段で検証する。
+
+### 10-7. 2026-06-26: `make install` 後に Akaza が入力メニューから消える
+`make install && killall AkazaIME && pkill -9 -f akaza-server` 後に Akaza が選択不能になった。確認結果:
+
+- `~/Library/Input Methods/Akaza.app` は存在し、Info.plist の入力ソース定義も存在する
+- ただし `codesign -dv` の Identifier が `AkazaIME` になっており、`CFBundleIdentifier` の `com.github.tokuhirom.inputmethod.Japanese.Akaza` と不一致
+- `AppleEnabledInputSources` から Akaza が消えていた
+- `TISRegisterInputSource` / `TISEnableInputSource` は `status=0` を返すが、`TISSelectInputSource(Akaza.Japanese)` は `-50` のまま
+- `com.apple.hiservices-xpcservice` の connection invalid が TIS 操作時に継続して出る
+- 一方で AkazaIME プロセス自体には `activateServer` が来ており、プロセス生存と入力メニュー上の可用性が乖離している
+
+`make install` で未署名に近いバンドルを入れると LaunchServices / TIS / 署名 ID の整合が崩れる可能性があるため、`bundle` の最後に `codesign --force --deep --sign - out/Akaza.app` を追加した。以後の検証では、インストール後に `codesign -dv ~/Library/Input\ Methods/Akaza.app` の Identifier が `com.github.tokuhirom.inputmethod.Japanese.Akaza` であることを確認する。
+
 ## 付録: 即時回復手段（ユーザー向け）
 
 壊れた状態からの回復は、既知の IMKit バグ上は**ソフトウェア的手段が乏しい**が、2026-06-23 に **reboot 不要の回復**を確認した。

--- a/docs/sleep-wake-investigation.md
+++ b/docs/sleep-wake-investigation.md
@@ -120,6 +120,27 @@ macOS をスリープ→復帰すると、しばらくして（あるいは即�
 4. **経路A の堅牢化を試す** — 復帰時に `IMKServer` を作り直せるか、OS への再登録ができるか調査。
 5. **副次の H4 修正** — SIGTERM での graceful flush（学習データ消失対策、wedge とは独立に有益）。
 
+## 9. 原因確定（2026-06-22）: 往路（OS→IME のキーイベント配送）の断
+
+§8 の計測を入れたビルドで wedge が再発（土日 6/20-21 を挟んだ 6/22 09:15 の wake 後）。`~/Library/Logs/AkazaIME/akaza.log` の `[diag]` ログで**原因が確定した**。
+
+決定的な観測:
+| 事実 | 値 |
+|---|---|
+| 最後に `handle`（往路）が呼ばれた時刻 | **2026-06-19 19:18:26**（wake 前・金曜夜） |
+| 6/22 09:15:36 の wake 後の `handle` 件数 | **0 件**（約1時間ずっと） |
+| 同 wake 後の `activateServer`/`deactivateServer` | **43 件**（アプリ切替のたびに正常に到着） |
+| 全 client の応答性 | 一律 `insert=true mark=true`（client オブジェクトは生存） |
+
+結論:
+- **OS は AkazaIME を「アクティブな IME」として扱い続けている**（activate/deactivate は飛ぶ）。
+- **client オブジェクトは生きていて `insertText`/`setMarkedText` に応答できる**（＝復路は無傷）。
+- **だが keyDown が一切 `handle()` に配送されない**＝**OS のキーイベント配送経路（往路）だけが断たれている**。
+
+これは「復路の断」でも「in-process のドロップ」でもなく、**純粋に往路の断**。`killall` で回復しない事実（壊れているのは OS の HIToolbox/TSM のキールーティングで、Swift 再起動では OS がイベントを渡さない）とも、長時間スリープ（土日）で出やすい観察とも整合する。§6 の H1 が「往路の断・復路は生存」という具体形で確定。
+
+→ 次の課題は「**どの操作で往路が復活するか**」の切り分け（§7-1）。復活操作が分かれば、wake 通知時にそれをプログラムで自動実行する対策に直結する。有力候補は `TISSelectInputSource` による入力ソースの一時トグル（別ソースへ切替→Akaza へ戻す）で OS のキールーティングを張り直す案。
+
 ## 8. 投入した計測（2026-06-15）と次回 wedge 時の読み方
 
 `killall` で直らない＝原因は OS 側（経路A）に絞られたが、現状のログでは「往路（OS→IME のキーイベント配送）」と「復路（IME→アプリへの `insertText`/`setMarkedText`）」のどちらが断たれているか確定できない。これを次回発生時に一発で切り分けるため、経路A に計測ログを仕込んだ（ブランチ `debug/path-a-wake-logging`）。
@@ -149,8 +170,50 @@ macOS をスリープ→復帰すると、しばらくして（あるいは即�
 
 > この計測は原因特定後に削除する一時コード（全行 `[diag]`）。
 
+## 10. ライブ検証（2026-06-23）: 回復操作の切り分けと診断ツールの訂正
+
+6/23 に wedge が再発し、**発生中のライブ状態**で §7-1 の回復操作切り分けを実施した。重要な発見が3つ。
+
+### 10-1. 往路の断はプロセス全体で起きている（特定コントローラの問題ではない）
+wedge 中に打鍵すると、**新規に生成された `controller init` のコントローラでも `handle` が 0 件**だった（`activateServer` は来るが keyDown が来ない）。§9 の「往路の断」が、古いコントローラ固有ではなく **AkazaIME プロセス全体（OS↔IME 接続全体）** で起きていることが確定。
+
+### 10-2. 診断ツールの訂正 — TIS API と `defaults read` は wedge の真の状態を反映しない
+wedge 中・回復後の両方で、以下が**同じ表示**だった:
+- `/tmp/akaza_tis_dump`（`TISCreateInputSourceList` + `kTISPropertyInputSourceIsEnabled`）→ 常に `Akaza.Japanese: enabled=true`
+- `defaults read com.apple.HIToolbox AppleEnabledInputSources` → 常に Akaza が出てこない
+
+つまり**この2つは状態判定に使えない**。当初「AppleEnabledInputSources から Akaza が消えた＝disabled が原因」と考えたが、これは**誤り**（壊れていても回復していても表示が変わらない）。
+さらに、wedge 中に `TISEnableInputSource` / `TISDisableInputSource` / `TISSelectInputSource` トグル / **システム設定の「＋」での再追加**を試したが、いずれも状態を変えられなかった。
+→ **信用できる唯一の状態信号は `~/Library/Logs/AkazaIME/akaza.log` の `handle` 到着有無**（来ていれば往路は生存）。
+→ この結果、TIS API での自動再有効化を狙った **PR #109 は無効と判明しクローズ**した。
+
+### 10-3. 【最重要】`make install`（バンドル置換）で reboot 無しに回復した
+wedge 中に次を実行したところ**復活した**（akaza.log で `handle` 再開・7000件超を確認）:
+```sh
+make install && killall AkazaIME && pkill -9 -f akaza-server
+```
+このとき **wake は起きておらず、wake 時 IMKServer 再生成の実験（§10-4）は未発火**。効いたのは `make install` の中身——
+```
+rm -rf ~/Library/Input Methods/Akaza.app   # 旧バンドル削除
+cp -a out/Akaza.app ~/Library/Input Methods/  # 新バンドル設置
+```
+**バンドルがディスク上で置き換わると macOS が入力メソッドを再登録し、OS 側に溜まった壊れた接続/登録がクリアされた**、というのが最有力の説明。「`killall` 単独では治らない（＝同じバンドルに再接続するだけ）」事実とも整合する。
+⇒ **再登録が回復の鍵**であり、(a) reboot より軽い回復手段、(b) wake 時の予防（バンドル touch / 再登録 / `TISRegisterInputSource`）の有力候補。
+
+**未確定（次回の切り分け課題）**: 「バンドル置換そのもの」が効いたのか「単なる完全プロセス再起動」で十分なのか。次回 wedge 時は **まず `killall AkazaIME` だけ → ダメなら `make install`** の順で試し、どちらで治るかを記録する。
+
+### 10-4. 投入した予防実験（commit 7eef1b4, debug/path-a-wake-logging）
+wake 通知時に `akaza-server` 再起動に加えて **`IMKServer` 自体を作り直す**コードを `Sources/AkazaIME/main.swift` に追加（解放→runloop 1サイクル→同名で再 init、最大5回リトライ）。OS↔AkazaIME 接続が腐る前に張り直す狙い。**効果は未検証**（投入後まだ wake が起きていない）。次回以降の wake で `[diag] IMKServer recreated on wake` の有無と wedge 再発有無を観測する。最悪 IMKServer 再生成に失敗しても killall / 自動再起動で回復するため、reboot を要する現状より悪化はしない。
+
+### 10-5. 補足: 今回の wedge 直前にスリープは無かった
+pmset ログ上、wedge が顕在化した時刻の直前にスリープ/ロックは無く（Caffeine 稼働中）、当日朝の wake 由来の潜在破損が後から顕在化した可能性がある。⇒ **wake トリガだけの対策では取りこぼす恐れ**。署名/notarization 仮説は最有力だが未確定のまま（GUI 再追加時の trustd 署名検証バーストは状況証拠どまり）。
+
 ## 付録: 即時回復手段（ユーザー向け）
 
-壊れた状態からの回復は、既知の IMKit バグ上は**ソフトウェア的手段が乏しい**。
-- **`killall AkazaIME` は回復手段にならない（確認済み, 2026-06-15）。** 壊れた状態が OS 側にあるため、Swift プロセスを再起動しても直らない。
-- 試す価値があるのは（どれで直るかは未確認 = §7 の切り分け対象）: 入力ソースの再選択／システム設定で Akaza を削除→再追加／再ログイン／リブート。
+壊れた状態からの回復は、既知の IMKit バグ上は**ソフトウェア的手段が乏しい**が、2026-06-23 に **reboot 不要の回復**を確認した。
+
+- **【有効・確認済み 2026-06-23】`make install`（バンドル置換）で回復する。** `rm -rf ~/Library/Input Methods/Akaza.app` + 新バンドル設置により macOS が入力メソッドを再登録し、OS 側の壊れた接続/登録がクリアされる。実行例: `make install && killall AkazaIME`。
+- **`killall AkazaIME` 単独は回復手段にならない（確認済み, 2026-06-15）。** 同じバンドルに再接続するだけで OS 側の破損は残る。
+- TIS API（`TISEnableInputSource` 等のトグル）・システム設定での削除/再追加は **wedge 中は効かなかった**（2026-06-23）。
+- 最終手段: 再ログイン／リブート。
+- 状態判定は `defaults read` や TIS dump ではなく、**`~/Library/Logs/AkazaIME/akaza.log` に `handle` が来ているか**で行うこと（§10-2）。


### PR DESCRIPTION
## Summary

- Remove the wake-time IMKServer release/recreate experiment and keep the server lifetime fixed for the process.
- Sign the generated app bundle during make bundle so the signature identifier matches CFBundleIdentifier after install.
- Add docs/imkit-documentation-review.md with findings from the Apple InputMethodKit documentation review.
- Extend the sleep/wake investigation notes with the 2026-06-26 observations.

## Why

Apple's IMKit docs and SDK headers describe IMKServer as a single server object created by the input method process. The wake-time recreation experiment appears to have hung in IMKServer(name:bundleIdentifier:), leaving Akaza unavailable until the process was restarted. The documentation review also identifies follow-up hardening work around commitComposition(_:), stale async callbacks, TIS metadata, and custom candidate window placement.

## Validation

- swift test
- cargo test
- make install
- Verified installed app bundle signature identifier is com.github.tokuhirom.inputmethod.Japanese.Akaza.