### PR TITLE
[codex] Add TISInputSourceID to Info.plist

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -14,6 +14,8 @@
     <string>NSApplication</string>
     <key>CFBundleIdentifier</key>
     <string>com.github.tokuhirom.inputmethod.Japanese.Akaza</string>
+    <key>TISInputSourceID</key>
+    <string>com.github.tokuhirom.inputmethod.Japanese.Akaza</string>
     <key>CFBundleIconFile</key>
     <string>akaza.icns</string>
 


### PR DESCRIPTION
## Summary

- Add a top-level `TISInputSourceID` to `Info.plist`.
- Use the same identifier as `CFBundleIdentifier`: `com.github.tokuhirom.inputmethod.Japanese.Akaza`.

## Why

InputMethodKit and Text Input Services identify installed input sources through plist metadata. Making the input source ID explicit reduces ambiguity and makes the bundle metadata easier to inspect/debug when IMKit registration behaves unexpectedly.

## Validation

- `plutil -lint Info.plist`
- `plutil -p Info.plist`
- `swift test`