### PR TITLE
Secure Event Input の検出・警告を追加 — スリープ復帰 wedge の根本原因確定

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,37 @@ tail -50 ~/Library/Logs/AkazaIME/akaza.log
 make install && killall AkazaIME
 ```
 
+## Known Issues
+
+### 突然日本語入力が全アプリで効かなくなる（Secure Event Input）
+
+どこかのアプリが Secure Keyboard Entry（`EnableSecureEventInput`）を有効にしたまま解放しないと、
+macOS は**キーイベントを IME に配送しなくなる**（パスワード入力保護のための OS の仕様）。
+Akaza のプロセスは生きていてエラーも出ないため、IME が壊れたように見えるが、Akaza 側の問題ではない。
+
+ターミナルアプリ（ghostty 等）は sudo / ssh などのパスワードプロンプトを検出すると
+自動で Secure Input を有効化するため、解放漏れが起きるとこの状態に張り付く。
+スリープ復帰後に起きやすいが、発症はパスワードプロンプト検出のタイミングなので復帰の数時間後もある。
+
+**確認方法**:
+
+- 入力メニュー（メニューバーの Akaza アイコン）に「⚠️ 「アプリ名」が Secure Input を有効化中 — 日本語入力不可」と表示される
+- または保持プロセスを直接調べる:
+
+```bash
+ioreg -l -w 0 | grep -o 'kCGSSessionSecureInputPID"=[0-9]*'
+ps -p <PID> -o pid,lstart,command
+```
+
+**回復方法**（リブート不要）:
+
+1. Secure Input を握っているアプリを再起動する（例: ghostty を Cmd+Q → 再起動）
+2. それでも解放されない場合（死んだ PID が保持者として残留することがある）:
+   **画面をロック（Ctrl+Cmd+Q）→ パスワードでロック解除**
+
+`killall AkazaIME` や Akaza の再インストールでは回復しない（Akaza 側に問題がないため）。
+調査の経緯は `docs/sleep-wake-investigation.md` を参照。
+
 ## 関連プロジェクト
 
 - [akaza](https://github.com/akaza-im/akaza) - Rust 製かな漢字変換エンジン (コア)

--- a/Sources/AkazaIME/AkazaInputController+Diagnostics.swift
+++ b/Sources/AkazaIME/AkazaInputController+Diagnostics.swift
@@ -65,5 +65,8 @@ extension AkazaInputController {
     override open func activateServer(_ sender: Any!) {
         super.activateServer(sender)
         NSLog("AkazaIME[diag]: activateServer id=\(diagID) \(AkazaInputController.diagClientDescription(sender))")
+        // Secure Input 中は keyDown が IME に届かない(= handle が来ない wedge に見える)。
+        // activateServer は Secure Input 中でも届くので、ここが検出ポイントとして最適。
+        SecureInputDiagnostics.logIfActive("activateServer")
     }
 }

--- a/Sources/AkazaIME/AkazaInputController+Menu.swift
+++ b/Sources/AkazaIME/AkazaInputController+Menu.swift
@@ -6,6 +6,16 @@ import InputMethodKit
 extension AkazaInputController {
     override func menu() -> NSMenu! {
         let menu = NSMenu()
+        // Secure Input を他プロセスが握っていると日本語入力が全アプリで効かなくなる。
+        // ユーザーがログを見なくても原因に気づけるよう、入力メニューに警告を出す。
+        if SecureInputDiagnostics.isActive {
+            let holder = SecureInputDiagnostics.holderName() ?? "不明なプロセス"
+            let warnItem = NSMenuItem(
+                title: "⚠️ 「\(holder)」が Secure Input を有効化中 — 日本語入力不可",
+                action: nil, keyEquivalent: "")
+            menu.addItem(warnItem)
+            menu.addItem(NSMenuItem.separator())
+        }
         let registerItem = NSMenuItem(
             title: "単語を登録...", action: #selector(registerWord(_:)), keyEquivalent: "")
         registerItem.target = self

--- a/Sources/AkazaIME/SecureInputDiagnostics.swift
+++ b/Sources/AkazaIME/SecureInputDiagnostics.swift
@@ -1,0 +1,63 @@
+import AppKit
+import Carbon
+import IOKit
+
+/// Secure Event Input の検出。
+///
+/// どこかのプロセスが Secure Keyboard Entry (`EnableSecureEventInput`) を有効にしている間、
+/// macOS はキーイベントを IME に配送しない（パスワード入力保護のための仕様）。
+/// このとき activateServer 等の制御メッセージは届き続けるため、
+/// 「プロセスは生きているのに handle だけ来ない」サイレント wedge に見える。
+///
+/// 2026-07-13 の調査で、スリープ復帰後 wedge の実際の原因がこれ
+/// （ターミナルアプリのパスワード検出による Secure Input の解放漏れ）と確定した。
+/// 詳細は docs/sleep-wake-investigation.md §11。
+enum SecureInputDiagnostics {
+    /// Secure Event Input が有効かどうか。
+    static var isActive: Bool {
+        IsSecureEventInputEnabled()
+    }
+
+    /// Secure Event Input を保持しているプロセスの PID。
+    /// IORegistry ルートの IOConsoleUsers / kCGSSessionSecureInputPID から取得する。
+    static func holderPID() -> pid_t? {
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        defer { IOObjectRelease(root) }
+        guard
+            let users = IORegistryEntryCreateCFProperty(
+                root, "IOConsoleUsers" as CFString, kCFAllocatorDefault, 0
+            )?.takeRetainedValue() as? [[String: Any]]
+        else { return nil }
+        for user in users {
+            if let pid = user["kCGSSessionSecureInputPID"] as? Int {
+                return pid_t(pid)
+            }
+        }
+        return nil
+    }
+
+    /// 保持プロセスのアプリ名（GUI アプリでなければ nil）。
+    static func holderName() -> String? {
+        guard let pid = holderPID() else { return nil }
+        return NSRunningApplication(processIdentifier: pid)?.localizedName
+    }
+
+    /// ログ用の保持プロセス説明。例: "pid=14255 Ghostty (com.mitchellh.ghostty)"
+    static func holderDescription() -> String {
+        guard let pid = holderPID() else { return "holder unknown" }
+        if let app = NSRunningApplication(processIdentifier: pid) {
+            let name = app.localizedName ?? "?"
+            let bundle = app.bundleIdentifier ?? "?"
+            return "pid=\(pid) \(name) (\(bundle))"
+        }
+        return "pid=\(pid)"
+    }
+
+    /// Secure Input が有効ならログに残す。呼び出し元の文脈を context で示す。
+    static func logIfActive(_ context: String) {
+        guard isActive else { return }
+        NSLog(
+            "AkazaIME[diag]: SECURE EVENT INPUT ACTIVE (\(holderDescription())) ctx=\(context) — キーイベントは IME に配送されない"
+        )
+    }
+}

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -103,6 +103,10 @@ NSWorkspace.shared.notificationCenter.addObserver(
 
     // IMKServer の wake 時再生成は 2026-06-26 に main thread を詰まらせる疑いが
     // 強くなったため行わない。経路A の回復はバンドル再登録側で検証する。
+
+    // スリープ復帰後 wedge の実原因は Secure Input の解放漏れだった(2026-07-13, docs §11)。
+    // wake 直後に状態を記録しておくと、後の wedge 発症時刻との相関が取れる。
+    SecureInputDiagnostics.logIfActive("didWake")
 }
 
 NSApplication.shared.run()

--- a/docs/sleep-wake-investigation.md
+++ b/docs/sleep-wake-investigation.md
@@ -2,7 +2,11 @@
 
 > mac-akaza で最も深刻かつ再発を繰り返しているバグ。本ドキュメントに経緯・証拠・仮説・次の一手を集約する。
 >
-> 最終更新: 2026-06-15
+> 最終更新: 2026-07-13
+>
+> **【解決 2026-07-13】根本原因は Secure Event Input の解放漏れと確定した。§11 を参照。**
+> IME 側のバグではなく、他プロセス（今回は ghostty）が Secure Keyboard Entry を
+> 有効化したまま解放しないことで、OS がキーイベントを IME に配送しなくなる仕様動作だった。
 
 ## 1. 症状
 
@@ -230,12 +234,90 @@ pmset ログ上、wedge が顕在化した時刻の直前にスリープ/ロッ�
 
 `make install` で未署名に近いバンドルを入れると LaunchServices / TIS / 署名 ID の整合が崩れる可能性があるため、`bundle` の最後に `codesign --force --deep --sign - out/Akaza.app` を追加した。以後の検証では、インストール後に `codesign -dv ~/Library/Input\ Methods/Akaza.app` の Identifier が `com.github.tokuhirom.inputmethod.Japanese.Akaza` であることを確認する。
 
+## 11. 【原因確定 2026-07-13】Secure Event Input の解放漏れ
+
+wedge がライブ再発し、これまでの全仮説を棄却する切り分けの末、根本原因を特定した。
+
+### 11-1. 今回の切り分けで全て陰性になった
+
+タイムライン: 07:10:30 FullWake → 07:54:37 まで `handle` 正常 → 09:24 以降 `handle` ゼロ（この間スリープ無し）。
+
+| 操作 | 結果 |
+|---|---|
+| `killall AkazaIME`（09:26, 09:27 の 2 回） | ✗ handle ゼロのまま |
+| `make install`（バンドル置換 + 署名確認済み） | ✗ **回復せず** — 6/23 の「バンドル置換で回復」と矛盾 |
+| 新規 controller 生成（ghostty id=2, Slack id=3/4） | ✗ activateServer は来るが handle ゼロ |
+| 入力ソーストグル（ABC→Akaza） | ✗ 回復せず — §9 の「新セッション生成で回復」仮説を反証 |
+| 別アプリ（Slack）で入力 | ✗ アプリ単位ではなくシステム全体の断 |
+
+### 11-2. 真犯人: Secure Event Input
+
+「activateServer は届くのに keyDown だけ全アプリで届かない」を仕様として説明できるのが
+**Secure Event Input**（`EnableSecureEventInput`）。どこかのプロセスが有効化している間、
+macOS はパスワード保護のため**キーイベントを IME に配送しない**（制御メッセージは届き続ける）。
+
+確認方法（wedge 中に実行して確定）:
+
+```sh
+ioreg -l -w 0 | grep -o 'kCGSSessionSecureInputPID"=[0-9]*'
+# → kCGSSessionSecureInputPID"=14255
+ps -p 14255 -o pid,lstart,command
+# → /Applications/Ghostty.app/Contents/MacOS/ghostty
+```
+
+**ghostty が Secure Input を握りっぱなしだった。** ghostty は端末の termios が
+「パスワード入力モード」（ECHO off + ICANON on）になるとメニューの Secure Keyboard Entry
+設定と無関係に自動で Secure Input を有効化する。全 TTY の termios を確認したところ
+パスワードモードのペインは存在せず、**ghostty 内部のカウンタが解放し損ねて張り付いた**状態
+（ghostty 側のバグの可能性が高い）。
+
+### 11-3. これまでの謎が全て説明される
+
+| これまでの観測 | Secure Input 説での説明 |
+|---|---|
+| activateServer は届くのに handle だけ来ない（§9） | Secure Input 中はキーイベントが IME をバイパスする仕様 |
+| プロセス全体・全アプリで断（§10-1） | Secure Input はシステムグローバル |
+| killall / バンドル置換 / TIS トグル / 再追加が全部無効 | IME 側には何の問題もないから |
+| リブート・再ログインで治る | ghostty が終了して Secure Input が解放される |
+| 6/22 の「自然回復」（§9） | ghostty が Secure Input を解放した瞬間。直前の controller init との相関は偶然 |
+| 6/23 の「make install で回復」（§10-3） | **偶然の一致**。今回バンドル置換では回復しなかった |
+| スリープ復帰との相関 | 復帰時のロック画面パスワード入力や、復帰前後のパスワードプロンプト検出の誤作動で張り付きやすい |
+| wake 直後ではなく数時間後に発症（§10-5, 今回も） | 発症タイミング＝ghostty がパスワードモードを検出した（解放し損ねた）時刻であり、wake そのものではない |
+
+### 11-4. 対処
+
+- **回復**: Secure Input を握っているプロセス（`ioreg` で特定）を再起動する。ghostty なら Cmd+Q → 再起動。リブート不要。
+- **【重要・2026-07-13 実測】保持プロセスを終了しても解放されないことがある。** 今回、旧 ghostty (pid 14255) を Cmd+Q で終了した後も `kCGSSessionSecureInputPID=14255`（死んだ PID）のまま残留し、`IsSecureEventInputEnabled()` も true を返し続けた（WindowServer セッション状態の腐敗）。この場合は **画面ロック（Ctrl+Cmd+Q）→ パスワードでロック解除** で解放される（loginwindow が Secure Input を取得→解放する際に腐った状態が上書きされる）。実際にこれで回復し、直後に `handle` の到着を確認した。
+- **検出（実装済み 2026-07-13）**: `Sources/AkazaIME/SecureInputDiagnostics.swift`
+  - `activateServer` 時に Secure Input 有効なら `SECURE EVENT INPUT ACTIVE (pid=... app...)` を akaza.log に記録
+  - wake 時（didWakeNotification）にも同様に記録
+  - 入力メニューに「⚠️ 「アプリ名」が Secure Input を有効化中 — 日本語入力不可」を表示
+- **予防**: mac-akaza 側では他プロセスの Secure Input を解放できない（OS の仕様）。ghostty 側の解放漏れバグの調査・報告は別途。
+
+### 11-5. 過去の診断コードの扱い
+
+§8 で投入した `[diag]` ログ（往路/復路の計測）は原因特定に決定的な役割を果たした
+（「handle だけ来ない」の確定が Secure Input 説への到達に必須だった）。
+Secure Input 検出を常設化した後、過剰な per-key ログは削減してよい。
+
 ## 付録: 即時回復手段（ユーザー向け）
 
-壊れた状態からの回復は、既知の IMKit バグ上は**ソフトウェア的手段が乏しい**が、2026-06-23 に **reboot 不要の回復**を確認した。
+**2026-07-13 に根本原因が Secure Event Input の解放漏れと確定した（§11）。回復手順は以下。**
 
-- **【有効・確認済み 2026-06-23】`make install`（バンドル置換）で回復する。** `rm -rf ~/Library/Input Methods/Akaza.app` + 新バンドル設置により macOS が入力メソッドを再登録し、OS 側の壊れた接続/登録がクリアされる。実行例: `make install && killall AkazaIME`。
-- **`killall AkazaIME` 単独は回復手段にならない（確認済み, 2026-06-15）。** 同じバンドルに再接続するだけで OS 側の破損は残る。
-- TIS API（`TISEnableInputSource` 等のトグル）・システム設定での削除/再追加は **wedge 中は効かなかった**（2026-06-23）。
-- 最終手段: 再ログイン／リブート。
-- 状態判定は `defaults read` や TIS dump ではなく、**`~/Library/Logs/AkazaIME/akaza.log` に `handle` が来ているか**で行うこと（§10-2）。
+1. 犯人を特定する:
+   ```sh
+   ioreg -l -w 0 | grep -o 'kCGSSessionSecureInputPID"=[0-9]*'
+   ps -p <PID> -o pid,lstart,command
+   ```
+2. そのプロセスを再起動する（ghostty なら Cmd+Q → 再起動）。リブート不要。
+3. **プロセス終了後も解放されない場合**（死んだ PID が残留する）: **画面ロック Ctrl+Cmd+Q → パスワードでロック解除**。2026-07-13 にこれで回復を実測（§11-4）。
+4. 入力メニューに「⚠️ … Secure Input を有効化中」が出ていれば、それが原因表示（実装済み）。
+
+過去に試して**効かなかった**手段（Secure Input が原因なので当然）:
+
+- `killall AkazaIME` 単独（2026-06-15, 2026-07-13）
+- `make install`（バンドル置換）— 2026-06-23 に「回復した」ように見えたのは偶然の一致（2026-07-13 に反証）
+- TIS API トグル・システム設定での削除/再追加（2026-06-23）
+- 入力ソースの手動トグル ABC→Akaza（2026-07-13）
+
+状態判定は `defaults read` や TIS dump ではなく、**`~/Library/Logs/AkazaIME/akaza.log` に `handle` が来ているか**で行うこと（§10-2）。


### PR DESCRIPTION
## 概要

スリープ復帰後に日本語変換が全アプリで効かなくなる「サイレント wedge」（数週間追跡してきた最悪バグ）の根本原因が **Secure Event Input の解放漏れ**と確定した。IME 側のバグではない。

## 根本原因

どこかのプロセス（今回は ghostty）が Secure Keyboard Entry（`EnableSecureEventInput`）を有効化したまま解放しないと、macOS はパスワード保護のため**キーイベントを IME に配送しなくなる**（仕様）。activateServer 等の制御メッセージは届き続けるため、「プロセス生存・エラー無し・handle だけゼロ」に見える。

2026-07-13 のライブ切り分けで、従来の仮説・回復手段をすべて棄却して確定:

| 操作 | 結果 |
|---|---|
| killall AkazaIME | ✗ |
| make install（バンドル置換）| ✗（6/23 の「回復」は偶然と判明）|
| 入力ソーストグル ABC→Akaza | ✗ |
| 新規 controller 生成（別アプリ含む）| ✗ |
| **Secure Input 保持プロセスの解消** | ✓ handle 即復活 |

ghostty 側の解放漏れは既知の未解決問題（ghostty-org/ghostty#10480、1.3.1 でも未修正）。さらに保持プロセスが死んでも PID が残留するケースがあり、その場合は画面ロック→パスワード解錠で解放されることを実測した。

## 変更内容

IME 側から他プロセスの Secure Input は解放できないため、「サイレント wedge」を「原因表示付きの即時診断」に変える:

- `SecureInputDiagnostics.swift` 新規追加: `IsSecureEventInputEnabled()` + IORegistry の `kCGSSessionSecureInputPID` から保持プロセスを特定
- activateServer / wake 時に有効なら akaza.log へ `SECURE EVENT INPUT ACTIVE (pid=… アプリ名)` を記録（キー内容は記録しない）
- 入力メニューに「⚠️ 「アプリ名」が Secure Input を有効化中 — 日本語入力不可」を表示
- README に Known Issues として確認方法・回復手順を記載
- docs/sleep-wake-investigation.md に §11（原因確定の全経緯）を追記

## 動作確認

- wedge 発生中の実機で、activateServer 時に `SECURE EVENT INPUT ACTIVE (pid=14255)` がログに出ることを確認
- Secure Input 解放後（画面ロック→解錠）、handle が再開し日本語変換が復活することを確認
- swiftlint 0 violations / make build 成功