### PR TITLE
make install 時に out/ 側バンドルの LaunchServices 登録を解除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ bundle: download-model
 install: build bundle
 	rm -rf "$(INSTALL_DIR)/Akaza.app"
 	cp -a $(APP) "$(INSTALL_DIR)/"
+	# out/ 側のバンドルが LaunchServices に登録されると入力メニューに
+	# 同じ入力モードが二重表示されるため、登録を解除しておく
+	/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -u "$(PWD)/$(APP)" || true
 
 clean:
 	rm -rf .build/ $(OUTDIR)/ target/


### PR DESCRIPTION
## 問題

入力メニュー(キーボードメニュー)に `Akaza (Japanese)` が 2 行表示される。

## 原因

ビルド成果物の `out/Akaza.app` が Spotlight 経由で LaunchServices に登録されると、インストール先の `~/Library/Input Methods/Akaza.app` と合わせて同一バンドル ID のアプリが 2 か所に存在する状態になり、TIS が同じ入力モードを二重に列挙する。

```
$ lsregister -dump | grep 'path:.*Akaza'
path: /Users/xxx/Library/Input Methods/Akaza.app
path: /Users/xxx/work/mac-akaza/out/Akaza.app   ← これが原因
```

## 対処

`make install` の最後に `lsregister -u` で `out/` 側の登録を解除する。

## 備考

- 既に二重表示が発生している環境では、この修正を入れた上で一度ログアウト→ログインすると TIS のキャッシュが再構築されて解消する
- `lsregister` が失敗してもインストール自体は成功させたいので `|| true` を付けている