### PR TITLE
Secure Input 検出時のユーザー通知を追加（デフォルトオフ）

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Diagnostics.swift
+++ b/Sources/AkazaIME/AkazaInputController+Diagnostics.swift
@@ -68,5 +68,6 @@ extension AkazaInputController {
         // Secure Input 中は keyDown が IME に届かない(= handle が来ない wedge に見える)。
         // activateServer は Secure Input 中でも届くので、ここが検出ポイントとして最適。
         SecureInputDiagnostics.logIfActive("activateServer")
+        SecureInputNotifier.check()
     }
 }

--- a/Sources/AkazaIME/GeneralSettingsView+Dict.swift
+++ b/Sources/AkazaIME/GeneralSettingsView+Dict.swift
@@ -1,0 +1,239 @@
+import Cocoa
+
+// MARK: - 辞書セクション（システム辞書・ユーザー辞書）
+
+extension GeneralSettingsView {
+    func setupDictViews(below aboveView: NSView) {
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(separator)
+
+        let dictSectionLabel = NSTextField(labelWithString: "辞書")
+        dictSectionLabel.font = NSFont.boldSystemFont(ofSize: NSFont.smallSystemFontSize)
+        dictSectionLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(dictSectionLabel)
+
+        NSLayoutConstraint.activate([
+            separator.topAnchor.constraint(equalTo: aboveView.bottomAnchor, constant: 16),
+            separator.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            separator.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+
+            dictSectionLabel.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 8),
+            dictSectionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20)
+        ])
+
+        let lastSystemView = setupSystemDictSection(below: dictSectionLabel)
+        setupUserDictSection(below: lastSystemView)
+    }
+
+    private func setupSystemDictSection(below aboveView: NSView) -> NSView {
+        let sysLabel = NSTextField(labelWithString: "システム辞書")
+        sysLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+        sysLabel.textColor = .secondaryLabelColor
+        sysLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(sysLabel)
+
+        NSLayoutConstraint.activate([
+            sysLabel.topAnchor.constraint(equalTo: aboveView.bottomAnchor, constant: 8),
+            sysLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20)
+        ])
+
+        var lastView: NSView = sysLabel
+        dictRowUpdaters = []
+
+        for config in predefinedDownloadableDicts {
+            let (rowView, update) = makeDownloadableDictRow(config: config)
+            dictRowUpdaters.append(update)
+
+            NSLayoutConstraint.activate([
+                rowView.topAnchor.constraint(equalTo: lastView.bottomAnchor, constant: 6),
+                rowView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+                rowView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -20)
+            ])
+            lastView = rowView
+        }
+
+        return lastView
+    }
+
+    private func makeDownloadableDictRow(
+        config: DownloadableDictConfig
+    ) -> (view: NSView, update: () -> Void) {
+        let container = NSView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(container)
+
+        let nameLabel = NSTextField(labelWithString: config.displayName)
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(nameLabel)
+
+        let statusLabel = NSTextField(labelWithString: "確認中...")
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(statusLabel)
+
+        let actionButton = NSButton(title: "", target: nil, action: nil)
+        actionButton.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(actionButton)
+
+        NSLayoutConstraint.activate([
+            nameLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            nameLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            nameLabel.widthAnchor.constraint(equalToConstant: 160),
+
+            statusLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 12),
+            statusLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            statusLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 80),
+
+            actionButton.leadingAnchor.constraint(equalTo: statusLabel.trailingAnchor, constant: 8),
+            actionButton.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            actionButton.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+
+            container.heightAnchor.constraint(equalToConstant: 24)
+        ])
+
+        let updateStatus = { [weak statusLabel, weak actionButton] in
+            guard let statusLabel = statusLabel, let actionButton = actionButton else { return }
+            let downloaded = akazaServerProcess.isDictDownloaded(config)
+            if downloaded {
+                statusLabel.stringValue = "読み込み済み"
+                statusLabel.textColor = .systemGreen
+                actionButton.title = "削除"
+                actionButton.action = #selector(GeneralSettingsView.deleteDictButtonClicked(_:))
+            } else {
+                statusLabel.stringValue = "未ダウンロード"
+                statusLabel.textColor = .systemOrange
+                actionButton.title = "ダウンロード"
+                actionButton.action = #selector(GeneralSettingsView.downloadDictButtonClicked(_:))
+            }
+        }
+
+        actionButton.target = self
+        actionButton.tag = predefinedDownloadableDicts.firstIndex(where: { $0.id == config.id }) ?? 0
+        updateStatus()
+
+        return (container, updateStatus)
+    }
+
+    private func setupUserDictSection(below aboveView: NSView) {
+        let userLabel = NSTextField(labelWithString: "ユーザー辞書")
+        userLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+        userLabel.textColor = .secondaryLabelColor
+        userLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(userLabel)
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("DictPath"))
+        column.title = "辞書パス"
+        column.resizingMask = .autoresizingMask
+        userDictTableView.addTableColumn(column)
+        userDictTableView.headerView = nil
+        userDictTableView.dataSource = self
+        userDictTableView.delegate = self
+
+        let scrollView = NSScrollView()
+        scrollView.documentView = userDictTableView
+        scrollView.hasVerticalScroller = true
+        scrollView.borderType = .bezelBorder
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scrollView)
+
+        addDictButton.target = self
+        addDictButton.action = #selector(addDictButtonClicked(_:))
+        addDictButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(addDictButton)
+
+        removeDictButton.target = self
+        removeDictButton.action = #selector(removeDictButtonClicked(_:))
+        removeDictButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(removeDictButton)
+
+        NSLayoutConstraint.activate([
+            userLabel.topAnchor.constraint(equalTo: aboveView.bottomAnchor, constant: 12),
+            userLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+
+            scrollView.topAnchor.constraint(equalTo: userLabel.bottomAnchor, constant: 6),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            scrollView.heightAnchor.constraint(equalToConstant: 100),
+
+            addDictButton.topAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 8),
+            addDictButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+
+            removeDictButton.centerYAnchor.constraint(equalTo: addDictButton.centerYAnchor),
+            removeDictButton.leadingAnchor.constraint(equalTo: addDictButton.trailingAnchor, constant: 8)
+        ])
+    }
+}
+
+// MARK: - 辞書セクションのアクション
+
+extension GeneralSettingsView {
+    @objc fileprivate func downloadDictButtonClicked(_ sender: NSButton) {
+        let index = sender.tag
+        guard index < predefinedDownloadableDicts.count else { return }
+        let config = predefinedDownloadableDicts[index]
+
+        sender.isEnabled = false
+        akazaServerProcess.downloadDict(config) { _ in
+            DispatchQueue.main.async { [weak self] in
+                sender.isEnabled = true
+                self?.dictRowUpdaters[index]()
+                akazaServerProcess.restart()
+            }
+        }
+    }
+
+    @objc fileprivate func deleteDictButtonClicked(_ sender: NSButton) {
+        let index = sender.tag
+        guard index < predefinedDownloadableDicts.count else { return }
+        let config = predefinedDownloadableDicts[index]
+
+        do {
+            try akazaServerProcess.deleteDict(config)
+        } catch {
+            NSLog("AkazaIME: failed to delete \(config.fileName): \(error)")
+        }
+        dictRowUpdaters[index]()
+        akazaServerProcess.restart()
+    }
+
+    @objc fileprivate func addDictButtonClicked(_ sender: NSButton) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.begin { [weak self] result in
+            guard result == .OK, let url = panel.url else { return }
+            DispatchQueue.main.async {
+                self?.selectEncoding(for: url)
+            }
+        }
+    }
+
+    private func selectEncoding(for url: URL) {
+        let alert = NSAlert()
+        alert.messageText = "エンコーディングを選択"
+        alert.informativeText = url.lastPathComponent
+        alert.addButton(withTitle: "追加")
+        alert.addButton(withTitle: "キャンセル")
+
+        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 150, height: 24))
+        popup.addItems(withTitles: ["UTF-8", "EUC-JP"])
+        alert.accessoryView = popup
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            let encoding = popup.indexOfSelectedItem == 1 ? "eucjp" : "utf8"
+            Settings.shared.additionalDictPaths.append("\(url.path):\(encoding)")
+            userDictTableView.reloadData()
+            akazaServerProcess.restart()
+        }
+    }
+
+    @objc fileprivate func removeDictButtonClicked(_ sender: NSButton) {
+        let row = userDictTableView.selectedRow
+        guard row >= 0 else { return }
+        Settings.shared.additionalDictPaths.remove(at: row)
+        userDictTableView.reloadData()
+        akazaServerProcess.restart()
+    }
+}

--- a/Sources/AkazaIME/GeneralSettingsView.swift
+++ b/Sources/AkazaIME/GeneralSettingsView.swift
@@ -8,14 +8,19 @@ class GeneralSettingsView: NSView {
         target: nil,
         action: nil
     )
+    private let notifyOnSecureInputCheckbox = NSButton(
+        checkboxWithTitle: "他アプリの Secure Input で日本語入力が無効になったら通知",
+        target: nil,
+        action: nil
+    )
     private let modelVersionLabel = NSTextField(labelWithString: "読み込み中...")
     private let modelBuildTimestampLabel = NSTextField(labelWithString: "")
-    private let userDictTableView = NSTableView()
-    private let addDictButton = NSButton(title: "+ 追加", target: nil, action: nil)
-    private let removeDictButton = NSButton(title: "- 削除", target: nil, action: nil)
+    let userDictTableView = NSTableView()
+    let addDictButton = NSButton(title: "+ 追加", target: nil, action: nil)
+    let removeDictButton = NSButton(title: "- 削除", target: nil, action: nil)
 
     // ダウンロード可能辞書の行ごとのステータス更新クロージャ
-    private var dictRowUpdaters: [() -> Void] = []
+    var dictRowUpdaters: [() -> Void] = []
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -52,6 +57,12 @@ class GeneralSettingsView: NSView {
         showPredictiveCandidatesCheckbox.action = #selector(showPredictiveCandidatesChanged(_:))
         addSubview(showPredictiveCandidatesCheckbox)
 
+        notifyOnSecureInputCheckbox.translatesAutoresizingMaskIntoConstraints = false
+        notifyOnSecureInputCheckbox.state = Settings.shared.notifyOnSecureInput ? .on : .off
+        notifyOnSecureInputCheckbox.target = self
+        notifyOnSecureInputCheckbox.action = #selector(notifyOnSecureInputChanged(_:))
+        addSubview(notifyOnSecureInputCheckbox)
+
         NSLayoutConstraint.activate([
             punctuationLabel.topAnchor.constraint(equalTo: topAnchor, constant: 20),
             punctuationLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
@@ -73,10 +84,16 @@ class GeneralSettingsView: NSView {
                 equalTo: romkanLabel.bottomAnchor, constant: 12),
             showPredictiveCandidatesCheckbox.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
             showPredictiveCandidatesCheckbox.trailingAnchor.constraint(
+                lessThanOrEqualTo: trailingAnchor, constant: -20),
+
+            notifyOnSecureInputCheckbox.topAnchor.constraint(
+                equalTo: showPredictiveCandidatesCheckbox.bottomAnchor, constant: 8),
+            notifyOnSecureInputCheckbox.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            notifyOnSecureInputCheckbox.trailingAnchor.constraint(
                 lessThanOrEqualTo: trailingAnchor, constant: -20)
         ])
 
-        let lastModelView = setupModelInfoViews(below: showPredictiveCandidatesCheckbox)
+        let lastModelView = setupModelInfoViews(below: notifyOnSecureInputCheckbox)
         setupDictViews(below: lastModelView)
     }
 
@@ -135,241 +152,11 @@ class GeneralSettingsView: NSView {
         return modelBuildKeyLabel
     }
 
-    private func setupDictViews(below aboveView: NSView) {
-        let separator = NSBox()
-        separator.boxType = .separator
-        separator.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(separator)
-
-        let dictSectionLabel = NSTextField(labelWithString: "辞書")
-        dictSectionLabel.font = NSFont.boldSystemFont(ofSize: NSFont.smallSystemFontSize)
-        dictSectionLabel.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(dictSectionLabel)
-
-        NSLayoutConstraint.activate([
-            separator.topAnchor.constraint(equalTo: aboveView.bottomAnchor, constant: 16),
-            separator.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            separator.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-
-            dictSectionLabel.topAnchor.constraint(equalTo: separator.bottomAnchor, constant: 8),
-            dictSectionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20)
-        ])
-
-        let lastSystemView = setupSystemDictSection(below: dictSectionLabel)
-        setupUserDictSection(below: lastSystemView)
-    }
-
-    private func setupSystemDictSection(below aboveView: NSView) -> NSView {
-        let sysLabel = NSTextField(labelWithString: "システム辞書")
-        sysLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-        sysLabel.textColor = .secondaryLabelColor
-        sysLabel.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(sysLabel)
-
-        NSLayoutConstraint.activate([
-            sysLabel.topAnchor.constraint(equalTo: aboveView.bottomAnchor, constant: 8),
-            sysLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20)
-        ])
-
-        var lastView: NSView = sysLabel
-        dictRowUpdaters = []
-
-        for config in predefinedDownloadableDicts {
-            let (rowView, update) = makeDownloadableDictRow(config: config)
-            dictRowUpdaters.append(update)
-
-            NSLayoutConstraint.activate([
-                rowView.topAnchor.constraint(equalTo: lastView.bottomAnchor, constant: 6),
-                rowView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-                rowView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -20)
-            ])
-            lastView = rowView
-        }
-
-        return lastView
-    }
-
-    private func makeDownloadableDictRow(
-        config: DownloadableDictConfig
-    ) -> (view: NSView, update: () -> Void) {
-        let container = NSView()
-        container.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(container)
-
-        let nameLabel = NSTextField(labelWithString: config.displayName)
-        nameLabel.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(nameLabel)
-
-        let statusLabel = NSTextField(labelWithString: "確認中...")
-        statusLabel.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(statusLabel)
-
-        let actionButton = NSButton(title: "", target: nil, action: nil)
-        actionButton.translatesAutoresizingMaskIntoConstraints = false
-        container.addSubview(actionButton)
-
-        NSLayoutConstraint.activate([
-            nameLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            nameLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            nameLabel.widthAnchor.constraint(equalToConstant: 160),
-
-            statusLabel.leadingAnchor.constraint(equalTo: nameLabel.trailingAnchor, constant: 12),
-            statusLabel.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            statusLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 80),
-
-            actionButton.leadingAnchor.constraint(equalTo: statusLabel.trailingAnchor, constant: 8),
-            actionButton.centerYAnchor.constraint(equalTo: container.centerYAnchor),
-            actionButton.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-
-            container.heightAnchor.constraint(equalToConstant: 24)
-        ])
-
-        let updateStatus = { [weak statusLabel, weak actionButton] in
-            guard let statusLabel = statusLabel, let actionButton = actionButton else { return }
-            let downloaded = akazaServerProcess.isDictDownloaded(config)
-            if downloaded {
-                statusLabel.stringValue = "読み込み済み"
-                statusLabel.textColor = .systemGreen
-                actionButton.title = "削除"
-                actionButton.action = #selector(GeneralSettingsView.deleteDictButtonClicked(_:))
-            } else {
-                statusLabel.stringValue = "未ダウンロード"
-                statusLabel.textColor = .systemOrange
-                actionButton.title = "ダウンロード"
-                actionButton.action = #selector(GeneralSettingsView.downloadDictButtonClicked(_:))
-            }
-        }
-
-        actionButton.target = self
-        actionButton.tag = predefinedDownloadableDicts.firstIndex(where: { $0.id == config.id }) ?? 0
-        updateStatus()
-
-        return (container, updateStatus)
-    }
-
-    private func setupUserDictSection(below aboveView: NSView) {
-        let userLabel = NSTextField(labelWithString: "ユーザー辞書")
-        userLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-        userLabel.textColor = .secondaryLabelColor
-        userLabel.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(userLabel)
-
-        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("DictPath"))
-        column.title = "辞書パス"
-        column.resizingMask = .autoresizingMask
-        userDictTableView.addTableColumn(column)
-        userDictTableView.headerView = nil
-        userDictTableView.dataSource = self
-        userDictTableView.delegate = self
-
-        let scrollView = NSScrollView()
-        scrollView.documentView = userDictTableView
-        scrollView.hasVerticalScroller = true
-        scrollView.borderType = .bezelBorder
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(scrollView)
-
-        addDictButton.target = self
-        addDictButton.action = #selector(addDictButtonClicked(_:))
-        addDictButton.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(addDictButton)
-
-        removeDictButton.target = self
-        removeDictButton.action = #selector(removeDictButtonClicked(_:))
-        removeDictButton.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(removeDictButton)
-
-        NSLayoutConstraint.activate([
-            userLabel.topAnchor.constraint(equalTo: aboveView.bottomAnchor, constant: 12),
-            userLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-
-            scrollView.topAnchor.constraint(equalTo: userLabel.bottomAnchor, constant: 6),
-            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            scrollView.heightAnchor.constraint(equalToConstant: 100),
-
-            addDictButton.topAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: 8),
-            addDictButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-
-            removeDictButton.centerYAnchor.constraint(equalTo: addDictButton.centerYAnchor),
-            removeDictButton.leadingAnchor.constraint(equalTo: addDictButton.trailingAnchor, constant: 8)
-        ])
-    }
-
 }
 
 // MARK: - Actions
 
 extension GeneralSettingsView {
-    @objc private func downloadDictButtonClicked(_ sender: NSButton) {
-        let index = sender.tag
-        guard index < predefinedDownloadableDicts.count else { return }
-        let config = predefinedDownloadableDicts[index]
-
-        sender.isEnabled = false
-        akazaServerProcess.downloadDict(config) { _ in
-            DispatchQueue.main.async { [weak self] in
-                sender.isEnabled = true
-                self?.dictRowUpdaters[index]()
-                akazaServerProcess.restart()
-            }
-        }
-    }
-
-    @objc private func deleteDictButtonClicked(_ sender: NSButton) {
-        let index = sender.tag
-        guard index < predefinedDownloadableDicts.count else { return }
-        let config = predefinedDownloadableDicts[index]
-
-        do {
-            try akazaServerProcess.deleteDict(config)
-        } catch {
-            NSLog("AkazaIME: failed to delete \(config.fileName): \(error)")
-        }
-        dictRowUpdaters[index]()
-        akazaServerProcess.restart()
-    }
-
-    @objc private func addDictButtonClicked(_ sender: NSButton) {
-        let panel = NSOpenPanel()
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        panel.canChooseFiles = true
-        panel.begin { [weak self] result in
-            guard result == .OK, let url = panel.url else { return }
-            DispatchQueue.main.async {
-                self?.selectEncoding(for: url)
-            }
-        }
-    }
-
-    private func selectEncoding(for url: URL) {
-        let alert = NSAlert()
-        alert.messageText = "エンコーディングを選択"
-        alert.informativeText = url.lastPathComponent
-        alert.addButton(withTitle: "追加")
-        alert.addButton(withTitle: "キャンセル")
-
-        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 150, height: 24))
-        popup.addItems(withTitles: ["UTF-8", "EUC-JP"])
-        alert.accessoryView = popup
-
-        if alert.runModal() == .alertFirstButtonReturn {
-            let encoding = popup.indexOfSelectedItem == 1 ? "eucjp" : "utf8"
-            Settings.shared.additionalDictPaths.append("\(url.path):\(encoding)")
-            userDictTableView.reloadData()
-            akazaServerProcess.restart()
-        }
-    }
-
-    @objc private func removeDictButtonClicked(_ sender: NSButton) {
-        let row = userDictTableView.selectedRow
-        guard row >= 0 else { return }
-        Settings.shared.additionalDictPaths.remove(at: row)
-        userDictTableView.reloadData()
-        akazaServerProcess.restart()
-    }
-
     @objc private func punctuationStyleChanged(_ sender: NSPopUpButton) {
         if let style = PunctuationStyle(rawValue: sender.indexOfSelectedItem) {
             Settings.shared.punctuationStyle = style
@@ -378,6 +165,15 @@ extension GeneralSettingsView {
 
     @objc private func showPredictiveCandidatesChanged(_ sender: NSButton) {
         Settings.shared.showPredictiveCandidates = sender.state == .on
+    }
+
+    @objc private func notifyOnSecureInputChanged(_ sender: NSButton) {
+        let enabled = sender.state == .on
+        Settings.shared.notifyOnSecureInput = enabled
+        // 通知許可ダイアログはユーザーがオンにした瞬間（設定画面操作中）に出すのが自然
+        if enabled {
+            SecureInputNotifier.requestAuthorization()
+        }
     }
 
     private func loadModelInfo() {

--- a/Sources/AkazaIME/SecureInputDiagnostics.swift
+++ b/Sources/AkazaIME/SecureInputDiagnostics.swift
@@ -42,6 +42,12 @@ enum SecureInputDiagnostics {
         return NSRunningApplication(processIdentifier: pid)?.localizedName
     }
 
+    /// 保持プロセスの bundle identifier（GUI アプリでなければ nil）。
+    static func holderBundleIdentifier() -> String? {
+        guard let pid = holderPID() else { return nil }
+        return NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
+    }
+
     /// ログ用の保持プロセス説明。例: "pid=14255 Ghostty (com.mitchellh.ghostty)"
     static func holderDescription() -> String {
         guard let pid = holderPID() else { return "holder unknown" }

--- a/Sources/AkazaIME/SecureInputNotifier.swift
+++ b/Sources/AkazaIME/SecureInputNotifier.swift
@@ -1,0 +1,62 @@
+import AppKit
+import UserNotifications
+
+/// Secure Event Input 検出時のユーザー通知。
+///
+/// Secure Input wedge はログ (akaza.log) と入力メニューの警告だけでは気づきにくい
+/// （2026-07-23 の再発時、警告は11回記録されていたがユーザーは気づけなかった）。
+/// 設定 `notifyOnSecureInput` が有効なときのみ通知センターに警告を出す。デフォルトはオフ。
+enum SecureInputNotifier {
+    private static let notificationIdentifier = "secure-input-active"
+
+    /// 同一の有効化エピソード内で通知済みか。
+    /// activateServer は数秒おきに連発するため、エピソードの最初の1回だけ通知する。
+    /// Secure Input が解放されたことを観測したらリセットする。
+    private static var notifiedThisEpisode = false
+
+    /// Secure Input の状態を確認し、必要なら通知する。
+    /// activateServer / didWake など、Secure Input 中でも届くイベントから呼ぶ。
+    static func check() {
+        guard Settings.shared.notifyOnSecureInput else { return }
+        guard SecureInputDiagnostics.isActive else {
+            notifiedThisEpisode = false
+            return
+        }
+        // ロック画面 (loginwindow) の保持は正当かつ一時的なので通知しない。
+        // didWake 時はほぼ毎回 loginwindow が保持しているため、これを除外しないと wake のたびに鳴る。
+        if SecureInputDiagnostics.holderBundleIdentifier() == "com.apple.loginwindow" {
+            return
+        }
+        guard !notifiedThisEpisode else { return }
+        notifiedThisEpisode = true
+        deliver(holderName: SecureInputDiagnostics.holderName())
+    }
+
+    /// 通知許可をリクエストする。設定でオンにしたタイミング（ユーザー操作中）に呼ぶ。
+    static func requestAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { granted, error in
+            if let error {
+                NSLog("AkazaIME: notification authorization failed: \(error)")
+            } else if !granted {
+                NSLog("AkazaIME: notification authorization denied")
+            }
+        }
+    }
+
+    private static func deliver(holderName: String?) {
+        let content = UNMutableNotificationContent()
+        content.title = "日本語入力が無効になっています"
+        let holder = holderName ?? "他のプロセス"
+        content.body =
+            "「\(holder)」が Secure Input を有効化しているため、キー入力が IME に届きません。"
+            + "解放されない場合は「\(holder)」を再起動してください。"
+        // identifier を固定し、既存通知を置き換えて積み上がらないようにする
+        let request = UNNotificationRequest(
+            identifier: notificationIdentifier, content: content, trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                NSLog("AkazaIME: failed to deliver secure input notification: \(error)")
+            }
+        }
+    }
+}

--- a/Sources/AkazaIME/Settings.swift
+++ b/Sources/AkazaIME/Settings.swift
@@ -12,11 +12,15 @@ class Settings {
 
     private enum DefaultsName {
         static let showPredictiveCandidates = "showPredictiveCandidates"
+        static let notifyOnSecureInput = "notifyOnSecureInput"
     }
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
-        defaults.register(defaults: [DefaultsName.showPredictiveCandidates: true])
+        defaults.register(defaults: [
+            DefaultsName.showPredictiveCandidates: true,
+            DefaultsName.notifyOnSecureInput: false
+        ])
     }
 
     var punctuationStyle: PunctuationStyle {
@@ -32,6 +36,13 @@ class Settings {
     var showPredictiveCandidates: Bool {
         get { defaults.bool(forKey: DefaultsName.showPredictiveCandidates) }
         set { defaults.set(newValue, forKey: DefaultsName.showPredictiveCandidates) }
+    }
+
+    // Secure Input wedge (他プロセスが Secure Event Input を握って日本語入力が死ぬ) の
+    // 検出時にユーザー通知を出すか。通知許可ダイアログを伴うためデフォルトはオフ。
+    var notifyOnSecureInput: Bool {
+        get { defaults.bool(forKey: DefaultsName.notifyOnSecureInput) }
+        set { defaults.set(newValue, forKey: DefaultsName.notifyOnSecureInput) }
     }
 
     var romkanTable: String {

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -107,6 +107,7 @@ NSWorkspace.shared.notificationCenter.addObserver(
     // スリープ復帰後 wedge の実原因は Secure Input の解放漏れだった(2026-07-13, docs §11)。
     // wake 直後に状態を記録しておくと、後の wedge 発症時刻との相関が取れる。
     SecureInputDiagnostics.logIfActive("didWake")
+    SecureInputNotifier.check()
 }
 
 NSApplication.shared.run()

--- a/Tests/AkazaIMETests/SettingsTests.swift
+++ b/Tests/AkazaIMETests/SettingsTests.swift
@@ -27,6 +27,22 @@ final class SettingsTests: XCTestCase {
         XCTAssertTrue(settings.showPredictiveCandidates)
     }
 
+    func testNotifyOnSecureInputDefaultsToFalse() {
+        let settings = Settings(defaults: defaults)
+
+        XCTAssertFalse(settings.notifyOnSecureInput)
+    }
+
+    func testNotifyOnSecureInputPersistsTrueAndFalseValues() {
+        let settings = Settings(defaults: defaults)
+
+        settings.notifyOnSecureInput = true
+        XCTAssertTrue(Settings(defaults: defaults).notifyOnSecureInput)
+
+        settings.notifyOnSecureInput = false
+        XCTAssertFalse(Settings(defaults: defaults).notifyOnSecureInput)
+    }
+
     func testShowPredictiveCandidatesPersistsFalseAndTrueValues() {
         let settings = Settings(defaults: defaults)
 


### PR DESCRIPTION
## 背景

Secure Input wedge（他プロセスが Secure Event Input を握って日本語入力が全アプリで死ぬ）は、akaza.log の警告と入力メニューの ⚠️ 表示だけでは気づきにくい。

2026-07-23 の再発時（保持者: Google Chrome）、`SECURE EVENT INPUT ACTIVE` 警告は akaza.log に11回記録されていたが、ユーザーは原因に気づけず Mac 再起動に至った。

## 変更内容

- **`SecureInputNotifier.swift`（新規）**: Secure Input 検出時に通知センターへ保持アプリ名つきの警告を出す
  - 既存の検出ポイント（`activateServer` / `didWake`）から `check()` を呼ぶ
  - 有効化エピソードごとに1回だけ通知（activateServer は数秒おきに連発するためスパム防止）
  - ロック画面 (`com.apple.loginwindow`) の正当な保持は通知しない（wake のたびに鳴るのを防ぐ）
  - 通知 identifier を固定し、通知センターに積み上がらない
- **設定 `notifyOnSecureInput`（デフォルトオフ）**: 設定画面に「他アプリの Secure Input で日本語入力が無効になったら通知」チェックボックスを追加。オンにした時点（ユーザー操作中）で通知許可をリクエストする
- **リファクタ**: GeneralSettingsView.swift が swiftlint の行数制限（file 400 / type body 250）を超えたため、辞書セクションを `GeneralSettingsView+Dict.swift` に切り出し（`+Romkan.swift` の前例に倣う。コード移動のみで変更なし）

## テスト

- `swift test` 11件全パス（`notifyOnSecureInput` のデフォルト値・永続化テストを追加）
- swiftlint --strict クリーン
- 実機でエンドツーエンド確認済み: `swift -e 'import Carbon; EnableSecureEventInput(); Thread.sleep(forTimeInterval: 10); DisableSecureEventInput()'` で Secure Input を握らせ、入力ソース切替（activateServer 発火）で通知バナーの表示を確認