### PR TITLE
akaza.log の起動時ローテーションを追加

### DIFF
--- a/Sources/AkazaIME/LogRotation.swift
+++ b/Sources/AkazaIME/LogRotation.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// akaza.log の起動時ローテーション。
+///
+/// stderr を dup2 でログファイルに直結しているため実行中のローテーションはできない。
+/// 起動時にサイズを確認し、上限を超えていたら 1 世代だけ退避する
+/// （akaza.log → akaza.log.1、既存の .1 は破棄）。
+/// 2026-07-23 時点で無制限のまま 194MB まで肥大化していたための対処。
+enum LogRotation {
+    /// この上限を超えていたら起動時に退避する。
+    /// IME は数週間起動しっぱなしになるため、運用中の肥大は許容し世代退避で回収する。
+    static let maxBytes = 10 * 1024 * 1024
+
+    /// logFile が maxBytes を超えていたら logFile.1 に退避する。
+    /// - Returns: 退避を行ったら true。
+    @discardableResult
+    static func rotateIfNeeded(
+        at logFile: URL,
+        maxBytes: Int = LogRotation.maxBytes,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard
+            let attrs = try? fileManager.attributesOfItem(atPath: logFile.path),
+            let size = attrs[.size] as? Int,
+            size > maxBytes
+        else { return false }
+
+        let rotated = logFile.appendingPathExtension("1")
+        do {
+            if fileManager.fileExists(atPath: rotated.path) {
+                try fileManager.removeItem(at: rotated)
+            }
+            try fileManager.moveItem(at: logFile, to: rotated)
+            return true
+        } catch {
+            // ローテーション失敗でロギング自体を止めない(既存ファイルへの追記を続ける)
+            NSLog("AkazaIME: log rotation failed: \(error)")
+            return false
+        }
+    }
+}

--- a/Sources/AkazaIME/main.swift
+++ b/Sources/AkazaIME/main.swift
@@ -40,6 +40,7 @@ private func setupLogging() {
     try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
 
     let logFile = logDir.appendingPathComponent("akaza.log")
+    LogRotation.rotateIfNeeded(at: logFile)
     if !FileManager.default.fileExists(atPath: logFile.path) {
         FileManager.default.createFile(atPath: logFile.path, contents: nil)
     }

--- a/Tests/AkazaIMETests/LogRotationTests.swift
+++ b/Tests/AkazaIMETests/LogRotationTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import XCTest
+
+@testable import AkazaIME
+
+final class LogRotationTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LogRotationTests.\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    private var logFile: URL { tempDir.appendingPathComponent("akaza.log") }
+    private var rotatedFile: URL { tempDir.appendingPathComponent("akaza.log.1") }
+
+    func testDoesNothingWhenFileIsMissing() {
+        XCTAssertFalse(LogRotation.rotateIfNeeded(at: logFile, maxBytes: 10))
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: rotatedFile.path))
+    }
+
+    func testDoesNothingWhenFileIsWithinLimit() throws {
+        try Data(repeating: 0x61, count: 10).write(to: logFile)
+
+        XCTAssertFalse(LogRotation.rotateIfNeeded(at: logFile, maxBytes: 10))
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: logFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: rotatedFile.path))
+    }
+
+    func testRotatesWhenFileExceedsLimit() throws {
+        try Data(repeating: 0x61, count: 11).write(to: logFile)
+
+        XCTAssertTrue(LogRotation.rotateIfNeeded(at: logFile, maxBytes: 10))
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: logFile.path))
+        XCTAssertEqual(try Data(contentsOf: rotatedFile).count, 11)
+    }
+
+    func testReplacesExistingRotatedFile() throws {
+        try Data(repeating: 0x62, count: 5).write(to: rotatedFile)
+        try Data(repeating: 0x61, count: 11).write(to: logFile)
+
+        XCTAssertTrue(LogRotation.rotateIfNeeded(at: logFile, maxBytes: 10))
+
+        XCTAssertEqual(try Data(contentsOf: rotatedFile).count, 11)
+    }
+}


### PR DESCRIPTION
## 背景

akaza.log はサイズ無制限で追記され続け、2026-07-23 時点で 194MB まで肥大化していた（2026-02 のログ導入以来ローテーションなし）。

## 変更内容

- `LogRotation.rotateIfNeeded(at:maxBytes:)`: 起動時にログが 10MB を超えていたら `akaza.log.1` に 1 世代退避する（既存の `.1` は破棄）
- stderr を `dup2` でログファイルに直結している構造上、実行中のローテーションはできないため起動時のみ。IME は数週間起動しっぱなしになるため運用中の肥大は許容し、再起動時に回収する方針
- ローテーション失敗時はロギングを止めず既存ファイルへの追記を継続

## テスト

- ファイル無し / 上限内 / 上限超過 / 退避先が既存 の4ケースを追加（15件全パス）
- swiftlint --strict クリーン