### PR TITLE
Secure Input 警告の正当性判定を追加（fcitx5 方式）

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Menu.swift
+++ b/Sources/AkazaIME/AkazaInputController+Menu.swift
@@ -8,7 +8,9 @@ extension AkazaInputController {
         let menu = NSMenu()
         // Secure Input を他プロセスが握っていると日本語入力が全アプリで効かなくなる。
         // ユーザーがログを見なくても原因に気づけるよう、入力メニューに警告を出す。
-        if SecureInputDiagnostics.isActive {
+        // フォーカス中アプリ自身の保持は本物のパスワード欄（正当・一時的）なので警告しない
+        // (fcitx5-macos PR #269 方式)。
+        if SecureInputDiagnostics.isActive && !SecureInputDiagnostics.holderLooksLegitimate() {
             let holder = SecureInputDiagnostics.holderName() ?? "不明なプロセス"
             let warnItem = NSMenuItem(
                 title: "⚠️ 「\(holder)」が Secure Input を有効化中 — 日本語入力不可",

--- a/Sources/AkazaIME/SecureInputDiagnostics.swift
+++ b/Sources/AkazaIME/SecureInputDiagnostics.swift
@@ -48,6 +48,23 @@ enum SecureInputDiagnostics {
         return NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
     }
 
+    /// 保持プロセスとフォーカス中アプリの bundleId 比較による正当性判定
+    /// (fcitx5-macos PR #269 の輸入)。
+    /// 一致 = フォーカス中アプリのパスワード欄による正当な Secure Input。
+    /// 不一致 = バックグラウンドアプリの解放漏れの疑い。
+    /// 判定不能（どちらかが nil）は疑わしい側 (false) に倒す。
+    static func isLegitimate(holderBundle: String?, frontmostBundle: String?) -> Bool {
+        guard let holderBundle, let frontmostBundle else { return false }
+        return holderBundle == frontmostBundle
+    }
+
+    /// 現在の保持プロセスがフォーカス中アプリ自身かどうか。
+    static func holderLooksLegitimate() -> Bool {
+        isLegitimate(
+            holderBundle: holderBundleIdentifier(),
+            frontmostBundle: NSWorkspace.shared.frontmostApplication?.bundleIdentifier)
+    }
+
     /// ログ用の保持プロセス説明。例: "pid=14255 Ghostty (com.mitchellh.ghostty)"
     static func holderDescription() -> String {
         guard let pid = holderPID() else { return "holder unknown" }
@@ -60,10 +77,12 @@ enum SecureInputDiagnostics {
     }
 
     /// Secure Input が有効ならログに残す。呼び出し元の文脈を context で示す。
+    /// front / legit は解放漏れか正当なパスワード入力かの事後判別用。
     static func logIfActive(_ context: String) {
         guard isActive else { return }
+        let front = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "?"
         NSLog(
-            "AkazaIME[diag]: SECURE EVENT INPUT ACTIVE (\(holderDescription())) ctx=\(context) — キーイベントは IME に配送されない"
+            "AkazaIME[diag]: SECURE EVENT INPUT ACTIVE (\(holderDescription())) front=\(front) legit=\(holderLooksLegitimate()) ctx=\(context) — キーイベントは IME に配送されない"
         )
     }
 }

--- a/Sources/AkazaIME/SecureInputNotifier.swift
+++ b/Sources/AkazaIME/SecureInputNotifier.swift
@@ -27,6 +27,11 @@ enum SecureInputNotifier {
         if SecureInputDiagnostics.holderBundleIdentifier() == "com.apple.loginwindow" {
             return
         }
+        // フォーカス中アプリ自身の保持は本物のパスワード欄（正当・一時的）なので通知しない。
+        // 解放漏れならフォーカスが他アプリに移った後の activateServer で不一致になり通知される。
+        if SecureInputDiagnostics.holderLooksLegitimate() {
+            return
+        }
         guard !notifiedThisEpisode else { return }
         notifiedThisEpisode = true
         deliver(holderName: SecureInputDiagnostics.holderName())
@@ -56,6 +61,9 @@ enum SecureInputNotifier {
         UNUserNotificationCenter.current().add(request) { error in
             if let error {
                 NSLog("AkazaIME: failed to deliver secure input notification: \(error)")
+            } else {
+                // 通知が実際に出たかを akaza.log から事後確認できるようにする
+                NSLog("AkazaIME: secure input notification delivered (holder=\(holder))")
             }
         }
     }

--- a/Tests/AkazaIMETests/SecureInputDiagnosticsTests.swift
+++ b/Tests/AkazaIMETests/SecureInputDiagnosticsTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import XCTest
+
+@testable import AkazaIME
+
+final class SecureInputDiagnosticsTests: XCTestCase {
+    func testLegitimateWhenHolderMatchesFrontmost() {
+        XCTAssertTrue(
+            SecureInputDiagnostics.isLegitimate(
+                holderBundle: "com.google.Chrome",
+                frontmostBundle: "com.google.Chrome"))
+    }
+
+    func testNotLegitimateWhenHolderDiffersFromFrontmost() {
+        XCTAssertFalse(
+            SecureInputDiagnostics.isLegitimate(
+                holderBundle: "com.google.Chrome",
+                frontmostBundle: "com.github.wez.wezterm"))
+    }
+
+    func testNotLegitimateWhenHolderIsUnknown() {
+        XCTAssertFalse(
+            SecureInputDiagnostics.isLegitimate(
+                holderBundle: nil,
+                frontmostBundle: "com.google.Chrome"))
+    }
+
+    func testNotLegitimateWhenFrontmostIsUnknown() {
+        XCTAssertFalse(
+            SecureInputDiagnostics.isLegitimate(
+                holderBundle: "com.google.Chrome",
+                frontmostBundle: nil))
+    }
+}


### PR DESCRIPTION
## 背景

現状の Secure Input 警告（メニュー ⚠️ / #115 の通知）は、フォーカス中アプリのパスワード欄で正当に有効化されたケースでも発火する。正当なケースで鳴り続けると警告が無視されるようになり、本当の解放漏れを見逃す。

## 変更内容

fcitx5-macos PR #269 のヒューリスティックを輸入:

- `SecureInputDiagnostics.isLegitimate(holderBundle:frontmostBundle:)`: 保持プロセスとフォーカス中アプリの bundleId を比較。**一致 = 本物のパスワード欄（正当・一時的）**、**不一致 = バックグラウンドアプリの解放漏れの疑い**。判定不能は疑わしい側に倒す
- メニュー ⚠️ と通知（`SecureInputNotifier`）の両方で、正当な保持は抑制。解放漏れならフォーカスが他アプリに移った直後の activateServer で不一致になるため、警告は失われない
- `logIfActive` のログに `front=` / `legit=` を追記（事後のインシデント調査用）
- 通知の配信成功時にもログを残すようにした（2026-07-23 の実機テストで「通知が出たかどうかがログから追えない」ことが分かったため）

## テスト

- `isLegitimate` の4ケース（一致 / 不一致 / holder 不明 / frontmost 不明）を追加、15件全パス
- swiftlint --strict クリーン