### PR TITLE
死んだプロセスが Secure Input を保持し続ける残留状態の警告を追加

### DIFF
--- a/Sources/AkazaIME/AkazaInputController+Menu.swift
+++ b/Sources/AkazaIME/AkazaInputController+Menu.swift
@@ -11,10 +11,17 @@ extension AkazaInputController {
         // フォーカス中アプリ自身の保持は本物のパスワード欄（正当・一時的）なので警告しない
         // (fcitx5-macos PR #269 方式)。
         if SecureInputDiagnostics.isActive && !SecureInputDiagnostics.holderLooksLegitimate() {
-            let holder = SecureInputDiagnostics.holderName() ?? "不明なプロセス"
-            let warnItem = NSMenuItem(
-                title: "⚠️ 「\(holder)」が Secure Input を有効化中 — 日本語入力不可",
-                action: nil, keyEquivalent: "")
+            let title: String
+            switch SecureInputDiagnostics.holderState() {
+            case .dead(let pid):
+                // 保持プロセスが死んでいる残留状態では再起動する対象がない。
+                // 実測で解放を確認済みの回復手段（画面ロック→解錠）を案内する。
+                title = "⚠️ 終了済みプロセス (pid=\(pid)) が Secure Input を保持中 — 画面ロック→解錠で解放"
+            case .alive, .unknown:
+                let holder = SecureInputDiagnostics.holderName() ?? "不明なプロセス"
+                title = "⚠️ 「\(holder)」が Secure Input を有効化中 — 日本語入力不可"
+            }
+            let warnItem = NSMenuItem(title: title, action: nil, keyEquivalent: "")
             menu.addItem(warnItem)
             menu.addItem(NSMenuItem.separator())
         }

--- a/Sources/AkazaIME/SecureInputDiagnostics.swift
+++ b/Sources/AkazaIME/SecureInputDiagnostics.swift
@@ -36,6 +36,33 @@ enum SecureInputDiagnostics {
         return nil
     }
 
+    /// 保持プロセスの生死を含む状態。
+    ///
+    /// 保持プロセスが終了しても Secure Input が API レベルで解放されず残留することがある
+    /// （2026-07-24 実測: wezterm 終了後も IsSecureEventInputEnabled()=true が 5 分以上継続）。
+    /// このとき「保持アプリを再起動してください」という案内は成立しないため、状態を区別する。
+    enum HolderState: Equatable {
+        /// 保持プロセスが生存している
+        case alive(pid: pid_t)
+        /// 保持プロセスは終了したが Secure Input が解放されていない（残留）
+        case dead(pid: pid_t)
+        /// 保持プロセスの PID が取得できない
+        case unknown
+    }
+
+    static func holderState() -> HolderState {
+        guard let pid = holderPID() else { return .unknown }
+        return isProcessAlive(pid) ? .alive(pid: pid) : .dead(pid: pid)
+    }
+
+    /// プロセスの生存確認。kill(pid, 0) はシグナルを送らず存在チェックだけを行う。
+    /// EPERM は「存在するが権限なし」なので生存扱い。
+    /// NSRunningApplication の nil は「GUI アプリでない」と「死んでいる」を区別できないため使わない。
+    static func isProcessAlive(_ pid: pid_t) -> Bool {
+        if kill(pid, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
     /// 保持プロセスのアプリ名（GUI アプリでなければ nil）。
     static func holderName() -> String? {
         guard let pid = holderPID() else { return nil }
@@ -73,7 +100,7 @@ enum SecureInputDiagnostics {
             let bundle = app.bundleIdentifier ?? "?"
             return "pid=\(pid) \(name) (\(bundle))"
         }
-        return "pid=\(pid)"
+        return isProcessAlive(pid) ? "pid=\(pid)" : "pid=\(pid) (terminated)"
     }
 
     /// Secure Input が有効ならログに残す。呼び出し元の文脈を context で示す。

--- a/Sources/AkazaIME/SecureInputNotifier.swift
+++ b/Sources/AkazaIME/SecureInputNotifier.swift
@@ -9,32 +9,67 @@ import UserNotifications
 enum SecureInputNotifier {
     private static let notificationIdentifier = "secure-input-active"
 
-    /// 同一の有効化エピソード内で通知済みか。
-    /// activateServer は数秒おきに連発するため、エピソードの最初の1回だけ通知する。
+    /// 直近に通知した保持者の状況。
+    /// activateServer は数秒おきに連発するため同一状況では 1 回だけ通知するが、
+    /// 「保持アプリを再起動したのに死んだ pid が Secure Input を握ったまま残留」のように
+    /// 状況が変わったら案内を更新して再通知したいので、bool ではなく状態で覚える。
     /// Secure Input が解放されたことを観測したらリセットする。
-    private static var notifiedThisEpisode = false
+    private enum NotifiedState: Equatable {
+        case none
+        case aliveHolder(pid: pid_t)
+        case deadHolder(pid: pid_t)
+        case unknownHolder
+    }
+    private static var notified: NotifiedState = .none
 
     /// Secure Input の状態を確認し、必要なら通知する。
     /// activateServer / didWake など、Secure Input 中でも届くイベントから呼ぶ。
     static func check() {
         guard Settings.shared.notifyOnSecureInput else { return }
         guard SecureInputDiagnostics.isActive else {
-            notifiedThisEpisode = false
+            notified = .none
             return
         }
-        // ロック画面 (loginwindow) の保持は正当かつ一時的なので通知しない。
-        // didWake 時はほぼ毎回 loginwindow が保持しているため、これを除外しないと wake のたびに鳴る。
-        if SecureInputDiagnostics.holderBundleIdentifier() == "com.apple.loginwindow" {
-            return
+        switch SecureInputDiagnostics.holderState() {
+        case .alive(let pid):
+            // ロック画面 (loginwindow) の保持は正当かつ一時的なので通知しない。
+            // didWake 時はほぼ毎回 loginwindow が保持しているため、これを除外しないと wake のたびに鳴る。
+            if SecureInputDiagnostics.holderBundleIdentifier() == "com.apple.loginwindow" {
+                return
+            }
+            // フォーカス中アプリ自身の保持は本物のパスワード欄（正当・一時的）なので通知しない。
+            // 解放漏れならフォーカスが他アプリに移った後の activateServer で不一致になり通知される。
+            if SecureInputDiagnostics.holderLooksLegitimate() {
+                return
+            }
+            guard notified != .aliveHolder(pid: pid) else { return }
+            notified = .aliveHolder(pid: pid)
+            deliver(body: bodyText(holderName: SecureInputDiagnostics.holderName()))
+        case .dead(let pid):
+            guard notified != .deadHolder(pid: pid) else { return }
+            notified = .deadHolder(pid: pid)
+            deliver(body: deadHolderBodyText(pid: pid))
+        case .unknown:
+            guard notified != .unknownHolder else { return }
+            notified = .unknownHolder
+            deliver(body: bodyText(holderName: nil))
         }
-        // フォーカス中アプリ自身の保持は本物のパスワード欄（正当・一時的）なので通知しない。
-        // 解放漏れならフォーカスが他アプリに移った後の activateServer で不一致になり通知される。
-        if SecureInputDiagnostics.holderLooksLegitimate() {
-            return
-        }
-        guard !notifiedThisEpisode else { return }
-        notifiedThisEpisode = true
-        deliver(holderName: SecureInputDiagnostics.holderName())
+    }
+
+    /// 保持プロセスが生きている（または不明な）場合の本文。再起動を案内する。
+    static func bodyText(holderName: String?) -> String {
+        let holder = holderName ?? "他のプロセス"
+        return "「\(holder)」が Secure Input を有効化しているため、キー入力が IME に届きません。"
+            + "解放されない場合は「\(holder)」を再起動してください。"
+    }
+
+    /// 保持プロセスが既に終了している場合の本文。
+    /// 死んだプロセスは再起動できないため、実測で解放を確認済みの回復手段
+    /// （画面ロック → 解錠、2026-07-13）を案内する。
+    static func deadHolderBodyText(pid: pid_t) -> String {
+        "Secure Input を有効化したプロセス (pid=\(pid)) は既に終了しましたが、"
+            + "Secure Input が解放されずに残っています。"
+            + "画面をロック（Ctrl+Cmd+Q）して解錠すると解放されることがあります。"
     }
 
     /// 通知許可をリクエストする。設定でオンにしたタイミング（ユーザー操作中）に呼ぶ。
@@ -48,16 +83,14 @@ enum SecureInputNotifier {
         }
     }
 
-    private static func deliver(holderName: String?) {
+    private static func deliver(body: String) {
         let content = UNMutableNotificationContent()
         content.title = "日本語入力が無効になっています"
-        let holder = holderName ?? "他のプロセス"
-        content.body =
-            "「\(holder)」が Secure Input を有効化しているため、キー入力が IME に届きません。"
-            + "解放されない場合は「\(holder)」を再起動してください。"
+        content.body = body
         // identifier を固定し、既存通知を置き換えて積み上がらないようにする
         let request = UNNotificationRequest(
             identifier: notificationIdentifier, content: content, trigger: nil)
+        let holder = SecureInputDiagnostics.holderDescription()
         UNUserNotificationCenter.current().add(request) { error in
             if let error {
                 NSLog("AkazaIME: failed to deliver secure input notification: \(error)")

--- a/Tests/AkazaIMETests/SecureInputDiagnosticsTests.swift
+++ b/Tests/AkazaIMETests/SecureInputDiagnosticsTests.swift
@@ -31,4 +31,37 @@ final class SecureInputDiagnosticsTests: XCTestCase {
                 holderBundle: "com.google.Chrome",
                 frontmostBundle: nil))
     }
+
+    func testIsProcessAliveForCurrentProcess() {
+        XCTAssertTrue(SecureInputDiagnostics.isProcessAlive(getpid()))
+    }
+
+    func testIsProcessAliveForExitedProcess() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/true")
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertFalse(SecureInputDiagnostics.isProcessAlive(process.processIdentifier))
+    }
+}
+
+final class SecureInputNotifierTests: XCTestCase {
+    func testBodyTextForAliveHolderSuggestsRestart() {
+        let body = SecureInputNotifier.bodyText(holderName: "WezTerm")
+        XCTAssertTrue(body.contains("WezTerm"))
+        XCTAssertTrue(body.contains("再起動"))
+    }
+
+    func testBodyTextForUnknownHolderUsesFallbackName() {
+        let body = SecureInputNotifier.bodyText(holderName: nil)
+        XCTAssertTrue(body.contains("他のプロセス"))
+    }
+
+    func testDeadHolderBodyTextSuggestsScreenLockNotRestart() {
+        let body = SecureInputNotifier.deadHolderBodyText(pid: 14345)
+        XCTAssertTrue(body.contains("pid=14345"))
+        XCTAssertTrue(body.contains("既に終了"))
+        XCTAssertTrue(body.contains("画面をロック"))
+        XCTAssertFalse(body.contains("再起動"))
+    }
 }


### PR DESCRIPTION
## 背景

2026-07-24 の実測で、Secure Input の保持プロセス (wezterm, pid 14345) を再起動して旧プロセスが終了した後も、`IsSecureEventInputEnabled()` が true のまま 5 分以上残留するケースを確認した。akaza.log では 09:06:26 以降 `holderDescription` がアプリ名解決不能の `(pid=14345)` になっており、死んだ pid が保持者として残っていた。

この状態で従来の通知・メニュー警告は「保持アプリを再起動してください」と案内するが、死んだプロセスは再起動できず、案内としては誤り（実際にユーザーが「再起動したのに治らない」状態になった）。

## 変更内容

- `SecureInputDiagnostics.holderState()`: `kill(pid, 0)` による生存確認で保持者を `alive` / `dead` / `unknown` に分類。`NSRunningApplication` の nil は「GUI アプリでない」と「死んでいる」を区別できないため使わない
- 通知 (`SecureInputNotifier`) とメニュー警告を dead の場合に出し分け、実測で解放を確認済みの回復手段（画面ロック Ctrl+Cmd+Q → 解錠、2026-07-13 実測）を案内
- 通知のエピソード管理を bool から保持者状態 (`NotifiedState`) に変更。「保持アプリを再起動 → 死んだ pid が残留」のように状況が変わったら案内を更新して再通知する
- `holderDescription()` に死んだ pid の場合 `(terminated)` を付与し、事後のログ調査で残留と判別できるようにする

## テスト

- `swift test` 全通過（`isProcessAlive` の生存/終了プロセス判定、通知本文の出し分けをユニットテストで追加）
- `swiftlint --strict` 0 violations